### PR TITLE
stm32l4x6: small code changes in the build script

### DIFF
--- a/_targets/build.project.armv7m4-stm32l4x6
+++ b/_targets/build.project.armv7m4-stm32l4x6
@@ -1,5 +1,5 @@
 #
-# Shell script for building ia32-qemu project
+# Shell script for building armv7m4-stm32l4x6 project
 #
 # Copyright 2018, 2019, 2020 Phoenix Systems
 # Author: Kaja Swat, Aleksander Kaminski, Pawel Pisarczyk, Lukasz Kosinski
@@ -40,11 +40,11 @@ b_image_target() {
 	b_log "Creating image"
 
 	IMG=_boot/phoenix-${TARGET}.bin
-	PROGS="_build/armv7m4-stm32l4x6/prog/"
+	PROGS="_build/${TARGET}/prog"
 
 	phoenix-rtos-build/scripts/mkimg-stm32.sh \
-		$PROGS"phoenix-armv7m4-stm32l4x6.elf" "" $IMG \
-		"""$PROGS"stm32-multi";0""" """$PROGS"dummyfs";0""" """$PROGS"psh";0"""
+		"${PROGS}/phoenix-${TARGET}.elf" "" "${IMG}" \
+		"${PROGS}/stm32-multi;0" "${PROGS}/dummyfs;0" "${PROGS}/psh;0"
 }
 
 


### PR DESCRIPTION
```
${PROGS}/psh
```
Clearly shows than `PROGS` is directory.

Other changes:

- changed the script header.
- redundant double quotes have been removed
