### PR TITLE
build: docker: fix mounting tmpfs without executable permission

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -7,7 +7,7 @@ TMPFS_OVERLAY=()
 if [ "$(uname)" = "Darwin" ]; then
     # I/O operations on bind mounts in Darwin are painfully slow - use tmpfs for intermediate build artifacts
     chmod 777 "_build"  # fix against invalid tmpfs permissions
-    TMPFS_OVERLAY=("--tmpfs"  "/src/_build")
+    TMPFS_OVERLAY=("--tmpfs"  "/src/_build:exec")
 fi
 
 if [ "$#" -eq 1 ] && [ "$1" = "bash" ]; then


### PR DESCRIPTION
This fixes GH-30 for Darwin host platform.