### PR TITLE
imxrt106x: Fix buildling on MacOS

### DIFF
--- a/_targets/build.project.armv7m7-imxrt106x
+++ b/_targets/build.project.armv7m7-imxrt106x
@@ -50,11 +50,11 @@ PROGS=("dummyfs" "imxrt-multi" "psh" "imxrt-flash")
 
 
 b_mkscript() {
-	ksz=$((($(stat -c "%s" "${PREFIX_PROG_STRIPPED}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf") + SIZE_PAGE - 1) & PAGE_MASK))
+	ksz=$((($(wc -c < "${PREFIX_PROG_STRIPPED}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf") + SIZE_PAGE - 1) & PAGE_MASK))
 	poffs=$((KERNEL_OFFS + ksz))
 
 	for prog in "${PROGS[@]}"; do
-		psz=$((($(stat -c "%s" "${PREFIX_PROG_STRIPPED}$prog") + SIZE_PAGE - 1) & PAGE_MASK))
+		psz=$((($(wc -c < "${PREFIX_PROG_STRIPPED}$prog") + SIZE_PAGE - 1) & PAGE_MASK))
 		printf "@%s(%x:%x)\n" "$prog" "$poffs" "$psz" >> "$PREFIX_BUILD/plo/script.plo"
 		((poffs+=psz))
 	done
@@ -97,7 +97,7 @@ b_build_target() {
 b_add2img() {
 	printf "Copying %s (offs=%dB)\n" "$1" "$OFFSET"
 	dd if="$1" of="$2" bs=1 seek="$OFFSET" conv=notrunc 2>/dev/null
-	SZ=$((($(stat -c "%s" "$1") + SIZE_PAGE - 1) & PAGE_MASK))
+	SZ=$((($(wc -c < "$1") + SIZE_PAGE - 1) & PAGE_MASK))
 	OFFSET=$((OFFSET + SZ))
 }
 


### PR DESCRIPTION
Substitute non-portable `stat -c "%s" $1` with `wc -c < $1`.
Fixes #40.