### PR TITLE
Allow setting CONSOLE variable without overwriting it

### DIFF
--- a/_targets/build.project.ia32-generic
+++ b/_targets/build.project.ia32-generic
@@ -11,7 +11,8 @@ CROSS=i386-pc-phoenix-
 CFLAGS="-Os -Wall -Wstrict-prototypes -g -fomit-frame-pointer -fdata-sections -ffunction-sections -fno-builtin"
 LDFLAGS="-z max-page-size=0x1000"
 
-export CONSOLE=vga
+: ${CONSOLE=vga}
+export CONSOLE
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
 


### PR DESCRIPTION
Change is supposed to make possible building plo and kernel in serial mode by setting variable explicitly:

TARGET=ia32-generic CONSOLE=serial phoenix-rtos-build/build.sh ...

Referenced by:
https://github.com/phoenix-rtos/plo/pull/25
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/175