### PR TITLE
Added scripts to simplify running Phoenix-RTOS on QEMU (JIRA: PD-20)

### DIFF
--- a/scripts/qemu/ia32-generic-ata.sh
+++ b/scripts/qemu/ia32-generic-ata.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU with attached ATA drives (ia32-generic)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+# Add ATA drives
+while [ "$#" -gt 0 ]; do
+	DRIVES+=" -ata $1"
+	shift
+done
+
+exec bash "$(dirname "$BASH_SOURCE")/ia32-generic.sh" $DRIVES

--- a/scripts/qemu/ia32-generic-rtl.sh
+++ b/scripts/qemu/ia32-generic-rtl.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU with attached Realtek RTL8139 network card (ia32-generic)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+if [ "$#" -eq 0 ]; then
+	NETDEVS="-rtl user"
+else
+	NETDEVS="-rtl $*"
+fi
+
+exec bash "$(dirname "$BASH_SOURCE")/ia32-generic.sh" $NETDEVS

--- a/scripts/qemu/ia32-generic-vblk.sh
+++ b/scripts/qemu/ia32-generic-vblk.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU with attached VirtIO drives (ia32-generic)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+# Add VirtIO drives
+while [ "$#" -gt 0 ]; do
+	DRIVES+=" -vblk $1"
+	shift
+done
+
+exec bash "$(dirname "$BASH_SOURCE")/ia32-generic.sh" $DRIVES

--- a/scripts/qemu/ia32-generic-vgpu.sh
+++ b/scripts/qemu/ia32-generic-vgpu.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU with attached VirtIO GPU device (ia32-generic)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+# Add VirtIO GPU
+if [ "$#" -gt 1 ]; then
+	echo "Usage: $0 [outputs]"
+	exit 1
+fi
+
+exec bash "$(dirname "$BASH_SOURCE")/ia32-generic.sh" -vgpu $1

--- a/scripts/qemu/ia32-generic-vnet.sh
+++ b/scripts/qemu/ia32-generic-vnet.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU with attached VirtIO network card device (ia32-generic)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+if [ "$#" -eq 0 ]; then
+	NETDEVS="-vnet user"
+else
+	NETDEVS="-vnet $*"
+fi
+
+exec bash "$(dirname "$BASH_SOURCE")/ia32-generic.sh" $NETDEVS

--- a/scripts/qemu/ia32-generic.sh
+++ b/scripts/qemu/ia32-generic.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU (ia32-generic)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+DIR="$(dirname "$BASH_SOURCE")"                          # Script directory
+DRIVES="-hda $DIR/../../_boot/phoenix-ia32-generic.disk" # Default drives
+GPUS="-vga std"                                          # Default graphics adapters
+NETDEVS=""                                               # Default network devices
+SYSTEM="-serial stdio"                                   # Default system options
+
+# Device counters (used for generating device ID)
+ata=0
+vblk=0
+net=0
+
+# Parse args
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		# Print help message
+		-help|-h)
+			echo "Usage: $0 [options] or no args to run system image in default configuration"
+			echo -e "\t-ata|-ide <disk path>             - add ATA drive with given disk image"
+			echo -e "\t-virtio-blk|-vblk <disk path>     - add VirtIO block device with given disk image"
+			echo -e "\t-virtio-gpu|-vgpu [outputs]       - add VirtIO GPU device with 'outputs' connected displays"
+			echo -e "\t-virtio-net|-vnet <backend> [nic] - add VirtIO network device connected to given network backend"
+			echo -e "\t-help|-h                          - print help message"
+			echo -e "\tanything else                     - pass given option directly to QEMU startup command"
+			exit 1
+			;;
+		# Add ATA drive
+		-ata|-ide)
+			if [ -z "$2" ]; then
+				echo "$1: missing disk path"
+				exit 1
+			fi
+			DRIVES+=" -drive file=$2,if=none,id=ata$ata -device ide-hd,drive=ata$ata"
+			((ata++))
+			shift 2
+			;;
+		# Add VirtIO drive
+		-virtio-blk|-vblk)
+			if [ -z "$2" ]; then
+				echo "$1: missing disk path"
+				exit 1
+			fi
+			DRIVES+=" -drive file=$2,cache=unsafe,if=none,id=vblk$vblk -device virtio-blk-pci,drive=vblk$vblk"
+			((vblk++))
+			shift 2
+			;;
+		# Add VirtIO GPU device
+		-virtio-gpu|-vgpu)
+			GPUS+=" -device virtio-gpu-pci"
+			if [ -n "$2" ] && [ "$2" -eq "$2" ] 2> /dev/null; then
+				GPUS+=",max_outputs=$2"
+				shift
+			fi
+			shift
+			;;
+		# Add VirtIO network device
+		-virtio-net|-vnet)
+			if [ -z "$2" ]; then
+				echo "$1: missing backend"
+				exit 1
+			fi
+			NETDEVS+=" -netdev $2,id=net$net -device virtio-net-pci,netdev=net$net,id=nic$net"
+			if [ ! -z "$3" ] && case "$3" in -*) false;; esac; then
+				NETDEVS+=",$3"
+				shift
+			fi
+			((net++))
+			shift 2
+			;;
+		# Add Realtek RTL8139 network card
+		-rtl8139|-rtl)
+			if [ -z "$2" ]; then
+				echo "$1: missing backend"
+				exit 1
+			fi
+			NETDEVS+=" -netdev $2,id=net$net -device rtl8139,netdev=net$net,id=nic$net"
+			if [ ! -z "$3" ] && case "$3" in -*) false;; esac; then
+				NETDEVS+=",$3"
+				shift
+			fi
+			((net++))
+			shift 2
+			;;
+		# Pass other options directly to QEMU startup command
+		*)
+			SYSTEM+=" $1"
+			shift
+			;;
+	esac
+done
+
+# Print and execute QEMU command
+echo "qemu-system-i386 $DRIVES $GPUS $NETDEVS $SYSTEM" && exec qemu-system-i386 $DRIVES $GPUS $NETDEVS $SYSTEM

--- a/scripts/qemu/riscv64-virt-vblk.sh
+++ b/scripts/qemu/riscv64-virt-vblk.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU with attached VirtIO drives (riscv64-virt)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+# Add VirtIO drives
+while [ "$#" -gt 0 ]; do
+	DRIVES+=" -vblk $1"
+	shift
+done
+
+exec bash "$(dirname "$BASH_SOURCE")/riscv64-virt.sh" $DRIVES

--- a/scripts/qemu/riscv64-virt-vgpu.sh
+++ b/scripts/qemu/riscv64-virt-vgpu.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU with attached VirtIO GPU device (riscv64-virt)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+# Add VirtIO GPU
+if [ "$#" -gt 1 ]; then
+	echo "Usage: $0 [outputs]"
+	exit 1
+fi
+
+exec bash "$(dirname "$BASH_SOURCE")/riscv64-virt.sh" -vgpu $1

--- a/scripts/qemu/riscv64-virt-vnet.sh
+++ b/scripts/qemu/riscv64-virt-vnet.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU with attached VirtIO network card device (riscv64-virt)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+if [ "$#" -eq 0 ]; then
+	NETDEVS="-vnet user"
+else
+	NETDEVS="-vnet $*"
+fi
+
+exec bash "$(dirname "$BASH_SOURCE")/riscv64-virt.sh" $NETDEVS

--- a/scripts/qemu/riscv64-virt.sh
+++ b/scripts/qemu/riscv64-virt.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU (riscv64-virt)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+DIR="$(dirname "$BASH_SOURCE")"                                                       # Script directory
+DRIVES=""                                                                             # Default drives
+GPUS=""                                                                               # Default graphics adapters
+NETDEVS=""                                                                            # Default network devices
+SYSTEM="-machine virt -serial stdio -bios $DIR/../../_boot/phoenix-riscv64-virt.osbi" # Default system options
+
+# Device counters (used for generating device ID)
+vblk=0
+net=0
+
+# Parse args
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		# Print help message
+		-help|-h)
+			echo "Usage: $0 [options] or no args to run system image in default configuration"
+			echo -e "\t-virtio-blk|-vblk <disk path>     - add VirtIO block device with given disk image"
+			echo -e "\t-virtio-gpu|-vgpu [outputs]       - add VirtIO GPU device with 'outputs' connected displays"
+			echo -e "\t-virtio-net|-vnet <backend> [nic] - add VirtIO network device connected to given network backend"
+			echo -e "\t-help|-h                          - print help message"
+			echo -e "\tanything else                     - pass given option directly to QEMU startup command"
+			exit 1
+			;;
+		# Add MMIO VirtIO drive
+		-virtio-blk|-vblk)
+			if [ -z "$2" ]; then
+				echo "$1: missing disk path"
+				exit 1
+			fi
+			DRIVES+=" -drive file=$2,cache=unsafe,if=none,id=vblk$vblk -device virtio-blk-device,drive=vblk$vblk"
+			((vblk++))
+			shift 2
+			;;
+		# Add MMIO VirtIO GPU device
+		-virtio-gpu|-vgpu)
+			GPUS+=" -device virtio-gpu-device"
+			if [ -n "$2" ] && [ "$2" -eq "$2" ] 2> /dev/null; then
+				GPUS+=",max_outputs=$2"
+				shift
+			fi
+			shift
+			;;
+		# Add VirtIO network device
+		-virtio-net|-vnet)
+			if [ -z "$2" ]; then
+				echo "$1: missing backend"
+				exit 1
+			fi
+			NETDEVS+=" -netdev $2,id=net$net -device virtio-net-device,netdev=net$net,id=nic$net"
+			if [ ! -z "$3" ] && case "$3" in -*) false;; esac; then
+				NETDEVS+=",$3"
+				shift
+			fi
+			((net++))
+			shift 2
+			;;
+		# Pass other options directly to QEMU startup command
+		*)
+			SYSTEM+=" $1"
+			shift
+			;;
+	esac
+done
+
+# Print and execute QEMU command
+echo "qemu-system-riscv64 $DRIVES $GPUS $NETDEVS $SYSTEM" && exec qemu-system-riscv64 $DRIVES $GPUS $NETDEVS $SYSTEM


### PR DESCRIPTION
Added scripts allow to easily run Phoenix-RTOS image under QEMU with additional devices and options (e.g. with attached virtio devices). The general idea is to create a wrapper scripts for QEMU startup command. Each QEMU emulated target (ia32-generic and riscv64-virt for now) has a main startup script named 'target.sh' (e.g. ia32-generic.sh for ia32-generic target). The main script extends default qemu startup command with additional options which simplify device creation (e.g. -vblk, -vgpu or -vnet). One can still pass in original qemu options like -cpu, -smp or -kernel. There are also additional scripts named 'target-dev.sh'  which attach specific device to default system configuration (e.g. ia32-generic-vblk.sh runs default ia32-generic Phoenix-RTOS image with extra virtio-blk devices - attached disk images should be passed in as arguments). 

Examples:
./ia32-generic.sh - run default configuration (the system boots up to plo from default target image), 
./ia32-generic.sh -kernel ../../_build/ia32-generic/prog/phoenix-ia32 - run provided kernel directly without plo (example of original qemu options passthrough),
./ia32-generic-ata.sh ../../_boot/phoenix-ia32-generic.disk - demonstrates adding extra ATA drive to the system,