### PR TITLE
ia32-generic.sh: simpler checking of arguments

### DIFF
--- a/scripts/qemu/ia32-generic.sh
+++ b/scripts/qemu/ia32-generic.sh
@@ -54,10 +54,12 @@ while [ "$#" -gt 0 ]; do
 		# Add VirtIO GPU device
 		-virtio-gpu|-vgpu)
 			GPUS+=" -device virtio-gpu-pci"
-			if [ -n "$2" ] && [ "$2" -eq "$2" ] 2> /dev/null; then
-				GPUS+=",max_outputs=$2"
-				shift
-			fi
+			case "$2" in
+				[1-9])
+					GPUS+=",max_outputs=$2"
+					shift
+					;;
+			esac
 			shift
 			;;
 		# Add VirtIO network device
@@ -67,10 +69,13 @@ while [ "$#" -gt 0 ]; do
 				exit 1
 			fi
 			NETDEVS+=" -netdev $2,id=net$net -device virtio-net-pci,netdev=net$net,id=nic$net"
-			if [ ! -z "$3" ] && case "$3" in -*) false;; esac; then
-				NETDEVS+=",$3"
-				shift
-			fi
+			case "$3" in
+				''|-*)
+					;;
+				*)
+					NETDEVS+=",$3"
+					shift
+			esac
 			((net++))
 			shift 2
 			;;
@@ -81,10 +86,13 @@ while [ "$#" -gt 0 ]; do
 				exit 1
 			fi
 			NETDEVS+=" -netdev $2,id=net$net -device rtl8139,netdev=net$net,id=nic$net"
-			if [ ! -z "$3" ] && case "$3" in -*) false;; esac; then
-				NETDEVS+=",$3"
-				shift
-			fi
+			case "$3" in
+				''|-*)
+					;;
+				*)
+					NETDEVS+=",$3"
+					shift
+			esac
 			((net++))
 			shift 2
 			;;
@@ -97,4 +105,5 @@ while [ "$#" -gt 0 ]; do
 done
 
 # Print and execute QEMU command
-echo "qemu-system-i386 $DRIVES $GPUS $NETDEVS $SYSTEM" && exec qemu-system-i386 $DRIVES $GPUS $NETDEVS $SYSTEM
+echo "qemu-system-i386 $DRIVES $GPUS $NETDEVS $SYSTEM"
+exec qemu-system-i386 $DRIVES $GPUS $NETDEVS $SYSTEM


### PR DESCRIPTION
I changed the argument checking for:
`-virtio-gpu|-vgpu`
`-virtio-net|-vnet`
`-rtl8139|-rtl`

I think that using `case...esac` in this case will be better.
In `-vgpu` I assumed a range of numbers `1-9` ( this can be changed of course ).

For me `echo && command` looks strange.

The same applies to `riscv64-virt.sh`.

To the author:
- Help for `-rtl8139|-rtl` is missing.
- Maybe it would be better to use subcommands instead of many scripts.
