### PR TITLE
project: add example of user app

### DIFF
--- a/_targets/build.project.armv7a7-imx6ull
+++ b/_targets/build.project.armv7a7-imx6ull
@@ -30,6 +30,12 @@ export PORTS_CURL=y
 #
 # Project specific build
 #
+b_build_project() {
+	b_log "Building user applications"
+	make -C "_user" all install
+}
+
+
 b_build_target() {
 
 	b_log "Building sample project for $TARGET"

--- a/_targets/build.project.armv7a9-zynq7000
+++ b/_targets/build.project.armv7a9-zynq7000
@@ -27,6 +27,12 @@ b_mkscript_preinit() {
 }
 
 
+b_build_project() {
+	b_log "Building user applications"
+	make -C "_user" all install
+}
+
+
 b_build_target() {
 	b_log "Building sample project for $TARGET"
 

--- a/_targets/build.project.armv7m4-stm32l4x6
+++ b/_targets/build.project.armv7m4-stm32l4x6
@@ -36,6 +36,11 @@ b_build_target() {
 	:
 }
 
+b_build_project() {
+	b_log "Building user applications"
+	make -C "_user" all install
+}
+
 b_image_target() {
 	b_log "Creating image"
 

--- a/_targets/build.project.armv7m7-imxrt106x
+++ b/_targets/build.project.armv7m7-imxrt106x
@@ -96,8 +96,10 @@ b_mkscript_user() {
 			esac;
 			printf "%s\n" "$cmd"
 		done
+
 		printf "\0"
 	} >> "$PREFIX_BUILD/plo/$NAME_USER_SCRIPT"
+
 }
 
 
@@ -116,6 +118,12 @@ b_mkscript_preinit() {
 		printf "call %s %s %08x\n" "$BOOT_DEVICE" "$NAME_USER_SCRIPT" "$MAGIC_USER_SCRIPT"
 		printf "\0"
 	} >> "$file"
+}
+
+
+b_build_project() {
+	b_log "Building user applications"
+	make -C "_user" all install
 }
 
 

--- a/_targets/build.project.armv7m7-imxrt117x
+++ b/_targets/build.project.armv7m7-imxrt117x
@@ -117,6 +117,12 @@ b_mkscript_preinit() {
 }
 
 
+b_build_project() {
+	b_log "Building user applications"
+	make -C "_user" all install
+}
+
+
 b_build_target() {
 
 	b_log "Building sample project for $TARGET"

--- a/_targets/build.project.ia32-generic
+++ b/_targets/build.project.ia32-generic
@@ -50,6 +50,11 @@ b_build_target() {
 	make -C "plo/ia32" clean all
 }
 
+b_build_project() {
+	b_log "Building user applications"
+	make -C "_user" all install
+}
+
 b_image_target() {
 	b_log "Creating image from $PREFIX_ROOTFS"
 

--- a/_targets/build.project.riscv64-spike
+++ b/_targets/build.project.riscv64-spike
@@ -32,6 +32,12 @@ export PORTS_CURL=y
 #
 # Project specific build
 #
+
+b_build_project() {
+	b_log "Building user applications"
+	make -C "_user" all install
+}
+
 b_build_target() {
 
 	b_log "Building sample project for $TARGET"

--- a/_targets/build.project.riscv64-virt
+++ b/_targets/build.project.riscv64-virt
@@ -32,6 +32,12 @@ export PORTS_CURL=y
 #
 # Project specific build
 #
+
+b_build_project() {
+	b_log "Building user applications"
+	make -C "_user" all install
+}
+
 b_build_target() {
 
 	b_log "Building sample project for $TARGET"

--- a/_user/Makefile
+++ b/_user/Makefile
@@ -1,0 +1,26 @@
+#
+# Makefile for user app
+#
+# Copyright 2021 Phoenix Systems
+#
+# %LICENSE%
+#
+
+include ../phoenix-rtos-build/Makefile.common
+
+.DEFAULT_GOAL := all
+
+# default path for the programs to be installed in rootfs
+DEFAULT_INSTALL_PATH := /usr/bin
+
+# read out all components
+ALL_MAKES := $(shell find . -mindepth 2 -name Makefile)
+include $(ALL_MAKES)
+
+# create generic targets
+DEFAULT_COMPONENTS := $(ALL_COMPONENTS)
+
+.PHONY: all install clean
+all: $(DEFAULT_COMPONENTS)
+install: $(patsubst %,%-install,$(DEFAULT_COMPONENTS))
+clean: $(patsubst %,%-clean,$(ALL_COMPONENTS))

--- a/_user/hello/Makefile
+++ b/_user/hello/Makefile
@@ -1,0 +1,10 @@
+#
+# Makefile for user application
+#
+# Copyright 2021 Phoenix Systems
+#
+
+NAME := hello
+LOCAL_SRCS := main.c
+
+include $(binary.mk)

--- a/_user/hello/main.c
+++ b/_user/hello/main.c
@@ -1,0 +1,24 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Hello World
+ *
+ * Example of user application
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+
+
+int main(void)
+{
+	printf("Hello World!!\n");
+
+	return 0;
+}


### PR DESCRIPTION
The main goal of this PR is to simplify usage of phoenix-rtos-project.
It contains the following changes:

1. **_user** - directory contains user applications and is built for each platform; output binaries are located in _/root/userbin_
2. For `imxrt106x`, `imxrt117x` and `zynq-7000`, programs are added to plo's script only if variable `TARGET_PROJECT` is empty.
3. One option is to add building of **_user** to each of the scripts in **phoenix-rtos-build/build-core-***. In this scenario **_user** is built each time.
4. The other approach is to create **_project** directory contains files for each for the platform, like `build.project-*-*-user` and there would be located building of **_user**. In this case, **_user** directory is built only for specific target.

**BEFORE MERGE:** Options 3 or 4 have to be chosen and files `_targets/build.project.*` have to be updated for each of the platform.