### PR TITLE
psh: add defuser hash in _targets

### DIFF
--- a/_targets/build.project.armv7a7-imx6ull
+++ b/_targets/build.project.armv7a7-imx6ull
@@ -11,6 +11,7 @@ CROSS=arm-phoenix-
 
 export BUSYBOX_CONFIG="$(realpath "busybox_config")"
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
+export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
 
 #
 # Ports configuration

--- a/_targets/build.project.armv7m4-stm32l4x6
+++ b/_targets/build.project.armv7m4-stm32l4x6
@@ -13,6 +13,7 @@ export BOARD_CONFIG=" -DUART_CONSOLE=2 -DTTY2=1 "
 
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
+export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
 
 #
 # Ports configuration

--- a/_targets/build.project.armv7m7-imxrt106x
+++ b/_targets/build.project.armv7m7-imxrt106x
@@ -11,6 +11,7 @@ CROSS=arm-phoenix-
 
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
+export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
 
 #
 # Ports configuration

--- a/_targets/build.project.armv7m7-imxrt117x
+++ b/_targets/build.project.armv7m7-imxrt117x
@@ -11,6 +11,7 @@ CROSS=arm-phoenix-
 
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
+export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
 
 #
 # Ports configuration

--- a/_targets/build.project.ia32-generic
+++ b/_targets/build.project.ia32-generic
@@ -14,6 +14,7 @@ CROSS=i386-pc-phoenix-
 export CONSOLE
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
+export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
 
 #
 # Ports configuration

--- a/_targets/build.project.riscv64-spike
+++ b/_targets/build.project.riscv64-spike
@@ -13,6 +13,7 @@ export RISCV_LOADER="bbl"
 #export RISCV_LOADER="opensbi"
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
+export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
 
 #
 # Ports configuration

--- a/_targets/build.project.riscv64-virt
+++ b/_targets/build.project.riscv64-virt
@@ -13,6 +13,7 @@ CROSS=riscv64-phoenix-
 export RISCV_LOADER="opensbi"
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
+export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
 
 #
 # Ports configuration


### PR DESCRIPTION
defuser password hash is added to each target using psh for testing of login feature in psh.
Hash corresponds to password: 1234

JIRA: PD-75