### PR TITLE
common.imxrt: create different preinit script for plo located in ram

### DIFF
--- a/_targets/build.common.imxrt
+++ b/_targets/build.common.imxrt
@@ -64,8 +64,8 @@ b_mkscript_user() {
 # - BOOT_DEVICE - name of the device from which script is called
 # - OFFS_USER_SCRIPT - offset on flash memory where user script is located
 b_mkscript_preinit() {
-	file="$PREFIX_BUILD/plo/script.plo"
 	mkdir -p "$PREFIX_BUILD/plo/"
+	printf "%s\n" "${PREINIT_SCRIPT[@]}" > "$PREFIX_BUILD/plo/ramscript.plo"
 
 	{
 		printf "%s\n" "${PREINIT_SCRIPT[@]}"
@@ -74,7 +74,7 @@ b_mkscript_preinit() {
 		printf "alias %s 0x%x 0x%x\n" "$NAME_USER_SCRIPT" "$OFFS_USER_SCRIPT" "$sz"
 		printf "call %s %s %08x\n" "$BOOT_DEVICE" "$NAME_USER_SCRIPT" "$MAGIC_USER_SCRIPT"
 		printf "\0"
-	} > "$file"
+	} > "$PREFIX_BUILD/plo/script.plo"
 }
 
 

--- a/_targets/build.project.armv7m7-imxrt106x
+++ b/_targets/build.project.armv7m7-imxrt106x
@@ -63,12 +63,12 @@ PREINIT_SCRIPT=(
 
 # Production user script contains applications to run Phoenix-RTOS
 USER_SCRIPT=(
-	"wait 2000"
 	"kernel ${BOOT_DEVICE}"
 	"app ${BOOT_DEVICE} -x dummyfs xip1 ocram2"
 	"app ${BOOT_DEVICE} -x imxrt-multi ocram2 ocram2"
 	"app ${BOOT_DEVICE} -x psh xip1 ocram2"
-	"app ${BOOT_DEVICE} imxrt-flash ocram2 ocram2")
+	"app ${BOOT_DEVICE} imxrt-flash ocram2 ocram2"
+	"wait 2000")
 
 
 # Example of user dev script which call remotely script
@@ -85,7 +85,7 @@ REMOTE_USER_SCRIPT=(
 	"app usb0 -x imxrt-multi itcm dtcm"
 	"app usb0 -x psh ocram2 ocram2"
 	"copy usb0 imxrt-flash flash1 0x15000 0"
-	"app flash1 imxrt-flash xip1 dtcm"
+	"app flash1 imxrt-flash ocram2 dtcm"
 	"go!")
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Preinit script for plo located in ram cannot call user script.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/plo/pull/103).
- [x] I will merge this PR by myself when appropriate.
