### PR TITLE
docker-build: build as root in container and fix permissions afterwards

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -12,9 +12,15 @@ fi
 
 if [ "$#" -eq 1 ] && [ "$1" = "bash" ]; then
     # run interactive shell - using ROOT user
-    exec docker run -it  --rm -v "$(pwd):/src" -w /src -e TARGET -e SYSPAGE -e CONSOLE --entrypoint bash $DOCKER_IMG_NAME
+    exec docker run -it --rm -v "$(pwd):/src" -w /src -e TARGET -e SYSPAGE -e CONSOLE --entrypoint bash $DOCKER_IMG_NAME
 else
-    # run build - use our own UID/GID to create files with correct owner
-    exec docker run -it --user "$DOCKER_USER" --rm -v "$(pwd):/src:delegated" -w /src "${TMPFS_OVERLAY[@]}" -e TARGET -e SYSPAGE -e CONSOLE $DOCKER_IMG_NAME "$@"
+    # FIXME: run build - use our own UID/GID to create files with correct owner
+    #exec docker run -it --user "$DOCKER_USER" --rm -v "$(pwd):/src:delegated" -w /src "${TMPFS_OVERLAY[@]}" -e TARGET -e SYSPAGE -e CONSOLE $DOCKER_IMG_NAME "$@"
+
+    # FOR NOW: run build as root to be able to overwrite files installed in toolchain
+    docker run -it --rm -v "$(pwd):/src:delegated" -w /src "${TMPFS_OVERLAY[@]}" -e TARGET -e SYSPAGE -e CONSOLE $DOCKER_IMG_NAME "$@"
+
+    # FIX file ownership in "_build"
+    docker run -it --rm -v "$(pwd):/src:delegated" -w /src "${TMPFS_OVERLAY[@]}" --entrypoint bash $DOCKER_IMG_NAME -c "chown -R $DOCKER_USER _build/ _fs/$TARGET _boot"
 fi
 


### PR DESCRIPTION
## Description

Change needed because new docker image will contain libphoenix
(libraries and headers) owned by root (cp -a refuses to preserve file
attrs if You're not the owner of the file).

Added separate step to fix file permissions in _boot (probably hardly
ever needed).

## Motivation and Context
Needed because of: 
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/113
 - https://github.com/phoenix-rtos/phoenix-rtos-docker/pull/3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
