### PR TITLE
Update map setup (MPU plo)

### DIFF
--- a/_targets/build.project.armv7m7-imxrt106x
+++ b/_targets/build.project.armv7m7-imxrt106x
@@ -50,11 +50,14 @@ MAGIC_USER_SCRIPT=$((0xdabaabad))
 
 # Pre-init script is launched before user script
 PREINIT_SCRIPT=(
-	"map itcm 0x0 0x40000 rwx"
-	"map dtcm 0x20000000 0x20028000 rw"
-	"map ocram2 0x20200000 0x2027fe00 rwx"
-	"map xip1 0x70000000 0x70400000 rx"
+	"map itcm 0x0 0x58000 rwx"
+	"map dtcm 0x20000000 0x20028000 rwx"
+	"map ocram2 0x20200000 0x20280000 rwxc"
+	"map aips14 0x40000000 0x40400000 rws"
+	"map aips5 0x42000000 0x42100000 rws"
 	"map xip2 0x60000000 0x64000000 rx"
+	"map xip1 0x70000000 0x70400000 rx"
+	"map flexspi 0x7f000000 0x80000000 rw"
 	"phfs usb0 1.2 phoenixd"
 	"phfs flash0 2.0 raw"
 	"phfs flash1 2.1 raw"

--- a/_targets/build.project.armv7m7-imxrt117x
+++ b/_targets/build.project.armv7m7-imxrt117x
@@ -51,8 +51,8 @@ MAGIC_USER_SCRIPT=$((0xdabaabad))
 # Pre-init script is launched before user script
 PREINIT_SCRIPT=(
 	"map itcm 0x0 0x40000 rwx"
-	"map dtcm 0x20000000 0x20028000 rw"
-	"map ocram2 0x202c0000 0x2033fe00 rwx"
+	"map dtcm 0x20000000 0x20028000 rwx"
+	"map ocram2 0x202c0000 0x20340000 rwxc"
 	"map xip1 0x30000000 0x30400000 rx"
 	"phfs com1 0.11 phoenixd"
 	"phfs flash0 2.0 raw"


### PR DESCRIPTION
For `imxrt106x`, current FlexRAM setup is `0xaabfffff` ([_init.S](https://github.com/phoenix-rtos/plo/blob/75e3f82897df2649d8b7d1b2e69120d6275ec02f/hal/armv7m/imxrt/10xx/_init.S#L191)):
* `dtcm` =5*32kB (160kB),
* `itcm`: 11*32kB (352kB),  *`itcm` map end address was adjusted to `0x58000`*

Adding peripherals mapping `AIPS1-4`, `AIPS-5` and FlexSPI memory map.
This setup was tested on evk-imxrt1064 and is the minimum required to enable MPU with `dummyfs`, `imxrt-multi` and `psh`.
The activation of MPU has been tested on evk-imxrt1064 target.

For `imxrt-117x`, adjust the alignment of `ocram2` to 512*1024 to make the pre-setting of MPU regions and memory maps in `plo` work. The activation of MPU has not been tested on imxrt117x target.

JIRA: RTOS-2

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Update project to recent changes in `plo` with MPU region configuration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (`evk-imxrt1064` with `plo` and in kernel enabled MPU, `nil-imxrt1176` only  with`plo`).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/plo/pull/102
- [ ] I will merge this PR by myself when appropriate.
