### PR TITLE
imx6ull: add summary nodes creation to JFFS2 image

### DIFF
--- a/_targets/build.project.armv7a7-imx6ull
+++ b/_targets/build.project.armv7a7-imx6ull
@@ -67,7 +67,11 @@ b_image_target() {
 	PATH="$(pwd)/_build/host-pc/prog/:$PATH"
 	IMG="$PREFIX_BOOT/phoenix-armv7a7-imx6ull.jffs2"
 
-	mkfs.jffs2 -n -U -m none -e $((64*4096)) -s 4096 -r "$PREFIX_ROOTFS"/ -o "$IMG"
+	mkfs.jffs2 -U -m none -e $((64*4096)) -s 4096 -r "$PREFIX_ROOTFS"/ -o "$IMG"
+	if sumtool -e $((64*4096)) -i "$IMG" -o "$IMG.tmp" 2> /dev/null; then
+		echo "JFFS2 Summary nodes created"
+		mv "$IMG.tmp" "$IMG"
+	fi
 
 	sz=$(du -k "$IMG" | awk '{ print $1 }')
 	echo "Filesystem size: ${sz}KB"


### PR DESCRIPTION
## Description
JFFS2 summary nodes make rootfs to be mounted 2-4x times faster.

Reintroduced from INC.

## Motivation and Context
JIRA: DTR-104

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
