### PR TITLE
_fs/root-skel: modify /etc/rc.psh script to run posixsrv and interactive psh

### DIFF
--- a/_fs/root-skel/etc/rc.psh
+++ b/_fs/root-skel/etc/rc.psh
@@ -1,4 +1,5 @@
 :{}:
 X /bin/posixsrv
-X /sbin/lwip rtl:0x18:11
-X /linuxrc
+X /bin/psh
+#X /sbin/lwip rtl:0x18:11
+#X /linuxrc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed default system image for ia32-generic to run posixsrv on startup. Related PR:
phoenix-rtos/plo/pull/139

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to [running busybox testsuite](https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/34/files#r692148932)
Related to phoenix-rtos/phoenix-rtos-project#173
[JIRA: RTOS-85](https://jira.phoenix-rtos.com/browse/RTOS-85)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
