### PR TITLE
imxrt1176: replace default upload method with usb0

### DIFF
--- a/_targets/build.project.armv7m7-imxrt117x
+++ b/_targets/build.project.armv7m7-imxrt117x
@@ -54,7 +54,7 @@ PREINIT_SCRIPT=(
 	"map dtcm 0x20000000 0x20028000 rwx"
 	"map ocram2 0x202c0000 0x20340000 rwxc"
 	"map xip1 0x30000000 0x30400000 rx"
-	"phfs com1 0.11 phoenixd"
+	"phfs usb0 1.2 phoenixd"
 	"phfs flash0 2.0 raw"
 	"console 0.10")
 
@@ -77,10 +77,10 @@ DEV_USER_SCRIPT=(
 
 REMOTE_USER_SCRIPT=(
 	"5a5aa5a5"
-	"kernel com1"
-	"app com1 -x dummyfs ocram2 ocram2"
-	"app com1 -x imxrt-multi itcm dtcm"
-	"app com1 -x psh ocram2 ocram2"
+	"kernel usb0"
+	"app usb0 -x dummyfs ocram2 ocram2"
+	"app usb0 -x imxrt-multi itcm dtcm"
+	"app usb0 -x psh ocram2 ocram2"
 	"go!")
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes shortly -->
Changing the default kernel and apps upload method from `com1` to `usb0` for the `imxrt1170` target. From that moment the uploading method becomes the same as `imxrt1064`  which means the method is unified for both targets.

JIRA: RTOS-99

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enable faster than upload on imxrt1170 target.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
