### PR TITLE
build: ramscript.plo was not \0 terminated

### DIFF
--- a/_targets/build.common
+++ b/_targets/build.common
@@ -65,7 +65,11 @@ b_mkscript_user() {
 # - OFFS_USER_SCRIPT - offset on flash memory where user script is located
 b_mkscript_preinit() {
 	mkdir -p "$PREFIX_BUILD/plo/"
-	printf "%s\n" "${PREINIT_SCRIPT[@]}" > "$PREFIX_BUILD/plo/ramscript.plo"
+
+	{
+		printf "%s\n" "${PREINIT_SCRIPT[@]}"
+		printf "\0"
+	} > "$PREFIX_BUILD/plo/ramscript.plo"
 
 	{
 		printf "%s\n" "${PREINIT_SCRIPT[@]}"


### PR DESCRIPTION
JIRA: RTOS-111

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Each plo script shall be `\0` terminated sting, while `ramscript.plo` is not properly terminated, thus when booting the image from RAM, the following error message is printed:
```
To many arguments
```
This change fixes issue #RTOS-111 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176, imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
