### PR TITLE
zynq7000: update preinit script and copy plo image to be reusable on qemu

### DIFF
--- a/_targets/build.project.armv7a9-zynq7000
+++ b/_targets/build.project.armv7a9-zynq7000
@@ -32,13 +32,15 @@ MAGIC_USER_SCRIPT=$((0xdabaabad))
 
 # Pre-init script is launched before user script
 PREINIT_SCRIPT=(
-	"map ddr 0x100000 0x900000 rwx"
+	"map kddr 0x100000 0x12ffff rwx"
+	"map ddr 0x130000 0x900000 rwx"
 	"map ocram1 0x00000000 0x00030000 rwx"
 	"phfs usb0 1.2 phoenixd"
 	"phfs uart0 0.0 phoenixd"
 	"phfs uart1 0.1 raw"
 	"phfs flash0 2.0 raw"
 	"console 0.1"
+	"echo on"
 	"wait 1000")
 
 
@@ -49,7 +51,6 @@ USER_SCRIPT=(
 	"app ${BOOT_DEVICE} -x zynq7000-uart ddr ddr"
 	"app ${BOOT_DEVICE} -x psh ddr ddr"
 	"go!")
-
 
 
 b_build_project() {
@@ -66,7 +67,11 @@ b_build_target() {
 	b_mkscript_user "${USER_SCRIPT[@]}"
 	b_mkscript_preinit
 
-	make -C plo all
+	make -C plo base
+
+	# plo image is reused only in loading system via qemu
+	cp "${PREFIX_PROG_STRIPPED}plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img" \
+		_boot/plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}-qemu.img
 
 	phoenix-rtos-build/scripts/mkimg-boot-zynq7000.sh \
 		"${PREFIX_PROG_STRIPPED}plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
1. Map definition was updated. The kernel is loaded to `kddr` and programs are loaded to `ddr` map.  The kernel allocates some additional memory above `.bss` section. In the previous configuration, plo has loaded programs in memory above kernel what caused that programs have been overwritten.

2. In order to run Phoenix-RTOS on qemu the plo has to be loaded into `OCRAM`. Copy of plo image without boot layout is copied into `_boot` directory. @agkaminski , unfortunately there will be two files, I remember our previous discussion ;) 

JIRA: PD-203

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (zynq7000, qemu-system-aarch64).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
