### PR TITLE
scripts/zynq7000: move flash image creation to build process

### DIFF
--- a/_targets/build.project.armv7a9-zynq7000
+++ b/_targets/build.project.armv7a9-zynq7000
@@ -78,14 +78,24 @@ b_build_target() {
 		"${PREFIX_PROG_STRIPPED}plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img" \
 		0
 
-	cp "${PREFIX_PROG_STRIPPED}plo-ram-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img" _boot/
-	cp "${PREFIX_PROG_STRIPPED}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" _boot/
+	cp "${PREFIX_PROG_STRIPPED}plo-ram-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img" "${PREFIX_BOOT}/"
+	cp "${PREFIX_PROG_STRIPPED}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" "${PREFIX_BOOT}/"
+}
+
+
+b_flash_image() {
+	local flash_path="${PREFIX_BOOT}/flash-armv7a9-zynq7000.bin"
+
+	rm -f "${flash_path}"
+	dd if="${PREFIX_BOOT}/phoenix-armv7a9-zynq7000.disk" of="${flash_path}" bs=4M 2>/dev/null
+	truncate -s 16M "${flash_path}" 2>/dev/null
 }
 
 
 b_image_target() {
 	b_prod_image
 	b_dev_image
+	b_flash_image
 }
 
 

--- a/scripts/armv7a9-zynq7000.sh
+++ b/scripts/armv7a9-zynq7000.sh
@@ -11,10 +11,12 @@ IMG_FLASH_QEMU="$(dirname "${BASH_SOURCE[0]}")/../_build/armv7a9-zynq7000/prog/f
 IMG_PHOENIX_ZYNQ7000="$(dirname "${BASH_SOURCE[0]}")/../_boot/phoenix-armv7a9-zynq7000.disk"
 DTB_ZYNQ7000="$(dirname "${BASH_SOURCE[0]}")/../scripts/zynq7000-zc702.dtb"
 
-if [[ ! -f "$IMG_PLO_ZYNQ7000" && ! -f "$IMG_PHOENIX_ZYNQ7000" && ! -f "$DTB_ZYNQ7000" ]]; then
-	echo "Missing required files, check $IMG_PLO_ZYNQ7000, $IMG_PHOENIX_ZYNQ7000 and $DTB_ZYNQ7000"
-	exit 1
-fi
+for FILE in "$IMG_PLO_ZYNQ7000" "$IMG_PHOENIX_ZYNQ7000" "$DTB_ZYNQ7000"; do
+    if [ ! -f "$FILE" ]; then
+        echo "Missing required file: $FILE"
+        exit 1
+    fi
+done
 
 # Create file as counterpart of NOR flash memory
 rm -f "$IMG_FLASH_QEMU"

--- a/scripts/armv7a9-zynq7000.sh
+++ b/scripts/armv7a9-zynq7000.sh
@@ -7,21 +7,15 @@
 #
 
 IMG_PLO_ZYNQ7000="$(dirname "${BASH_SOURCE[0]}")/../_boot/plo-armv7a9-zynq7000-qemu.img"
-IMG_FLASH_QEMU="$(dirname "${BASH_SOURCE[0]}")/../_build/armv7a9-zynq7000/prog/flash-armv7a9-zynq7000.bin"
-IMG_PHOENIX_ZYNQ7000="$(dirname "${BASH_SOURCE[0]}")/../_boot/phoenix-armv7a9-zynq7000.disk"
+IMG_FLASH_QEMU="$(dirname "${BASH_SOURCE[0]}")/../_boot/flash-armv7a9-zynq7000.bin"
 DTB_ZYNQ7000="$(dirname "${BASH_SOURCE[0]}")/../scripts/zynq7000-zc702.dtb"
 
-for FILE in "$IMG_PLO_ZYNQ7000" "$IMG_PHOENIX_ZYNQ7000" "$DTB_ZYNQ7000"; do
-    if [ ! -f "$FILE" ]; then
-        echo "Missing required file: $FILE"
-        exit 1
-    fi
+for FILE in "$IMG_PLO_ZYNQ7000" "$IMG_FLASH_QEMU" "$DTB_ZYNQ7000"; do
+	if [ ! -f "$FILE" ]; then
+		echo "Missing required file: $FILE"
+		exit 1
+	fi
 done
-
-# Create file as counterpart of NOR flash memory
-rm -f "$IMG_FLASH_QEMU"
-dd if="$IMG_PHOENIX_ZYNQ7000" of="$IMG_FLASH_QEMU" bs=4M
-truncate -s 16M "$IMG_FLASH_QEMU"
 
 exec qemu-system-aarch64 \
 	-M arm-generic-fdt-7series \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - fix file checking condition
 - move flash image creation to build process
 
JIRA: PD-203

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (qemu-system-aarch64).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
