### PR TITLE
Update submodules and make MIMXRT1170-EVK default board for imxrt117x target

### DIFF
--- a/_targets/build.project.armv7m7-imxrt117x
+++ b/_targets/build.project.armv7m7-imxrt117x
@@ -11,6 +11,8 @@
 
 CROSS=arm-phoenix-
 
+export BOARD_CONFIG=" -DUART1=1 -DUART_CONSOLE=1 "
+
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
 export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
@@ -56,7 +58,7 @@ PREINIT_SCRIPT=(
 	"map xip1 0x30000000 0x30400000 rx"
 	"phfs usb0 1.2 phoenixd"
 	"phfs flash0 2.0 raw"
-	"console 0.10")
+	"console 0.0")
 
 
 # Production user script contains applications to run Phoenix-RTOS


### PR DESCRIPTION
JIRA: RTOS-128

This commit changes the board setup for imxrt117x target to be able to run on MIMXRT1170-EVK by default.

Required submodules are also updated with this commit:

* plo d9d621d...f540178 (2):
  > flash-imxrt: fix chip erase for Winbond and Micron
  > flash-imxrt: add ISSI nor flash lookup table