### PR TITLE
_targets/armv7a7-imx6ull: don't write cleanmarkers when creating NAND jffs2 rootfs image

### DIFF
--- a/_targets/build.project.armv7a7-imx6ull
+++ b/_targets/build.project.armv7a7-imx6ull
@@ -64,7 +64,7 @@ b_image_target() {
 	PATH="$(pwd)/_build/host-pc/prog/:$PATH"
 	IMG="$PREFIX_BOOT/phoenix-armv7a7-imx6ull.jffs2"
 
-	mkfs.jffs2 -U -m none -e $((64*4096)) -s 4096 -r "$PREFIX_ROOTFS"/ -o "$IMG"
+	mkfs.jffs2 -U -m none -e $((64*4096)) -s 4096 -n -r "$PREFIX_ROOTFS"/ -o "$IMG"
 	if sumtool -e $((64*4096)) -i "$IMG" -o "$IMG.tmp" 2> /dev/null; then
 		echo "JFFS2 Summary nodes created"
 		mv "$IMG.tmp" "$IMG"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added option not to write jffs2 cleanmarkers to NAND jffs2 image.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
NAND cleanmarkers are written to metadata area.
[JIRA: DTR-244](https://jira.phoenix-rtos.com/browse/DTR-244)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
