### PR TITLE
_targets: add micropython environment variable

### DIFF
--- a/_targets/build.project.armv7m7-imxrt106x
+++ b/_targets/build.project.armv7m7-imxrt106x
@@ -28,6 +28,7 @@ export PORTS_LZO=n
 export PORTS_OPENVPN=n
 export PORTS_JANSSON=n
 export PORTS_CURL=n
+export PORTS_MICROPYTHON=n
 
 
 #

--- a/_targets/build.project.ia32-generic
+++ b/_targets/build.project.ia32-generic
@@ -32,7 +32,7 @@ export PORTS_LZO=y
 export PORTS_OPENVPN=y
 export PORTS_JANSSON=y
 export PORTS_CURL=y
-
+export PORTS_MICROPYTHON=y
 
 #
 # Platform dependent parameters


### PR DESCRIPTION
JIRA: PD-189

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adding micropython environment variable in build configurations of:
 - ia32-generic (default to `yes`)
 - imxrt106x (default to 'no')

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As phoenix-rtos supports micropython it should be enabled, or at least mentioned in tested target build configurations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic, imxrt1064.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
