### PR TITLE
run rc.psh on startup for ia32-generic target

### DIFF
--- a/_fs/root-skel/etc/rc.psh
+++ b/_fs/root-skel/etc/rc.psh
@@ -1,4 +1,4 @@
 :{}:
 X /bin/posixsrv
 X /sbin/lwip rtl:0x18:11
-X /linuxrc
+X /bin/psh

--- a/_targets/build.project.ia32-generic
+++ b/_targets/build.project.ia32-generic
@@ -74,7 +74,7 @@ USER_SCRIPT=(
 	"wait 1000"
 	"kernel $BOOT_DEVICE"
 	"app ${BOOT_DEVICE} -x pc-ata ram ram"
-	"app ${BOOT_DEVICE} -x psh ram ram"
+	"app ${BOOT_DEVICE} -x psh;-i;/etc/rc.psh ram ram"
 	"app ${BOOT_DEVICE} -x ${CONSOLE_APP} ram ram"
 	"go!"
 )


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- modify /etc/rc.psh to run psh after lwip and posixsrv start
- enable running /etc/rc.psh in loading script for ia32-generic target

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It may be useful, for example when running busybox test suite (JIRA: RTOS-59)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/101).
- [x] I will merge this PR by myself when appropriate.
