### PR TITLE
scripts: add ia32-generic script with net setup for testing purposes, specifying pentium3 cpu in all scripts

### DIFF
--- a/scripts/ia32-generic-test.sh
+++ b/scripts/ia32-generic-test.sh
@@ -7,6 +7,7 @@
 #
 
 exec qemu-system-i386 \
+	-cpu pentium3 \
 	-hda "$(dirname "${BASH_SOURCE[0]}")/../_boot/phoenix-ia32-generic.disk" \
 	-nographic \
 	-monitor none \

--- a/scripts/ia32-generic-test.sh
+++ b/scripts/ia32-generic-test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Shell script for running Phoenix-RTOS on QEMU for testing purposes (ia32-generic)
+#
+# Copyright 2022 Phoenix Systems
+# Author: Damian Loewnau
+#
+
+exec qemu-system-i386 \
+	-hda "$(dirname "${BASH_SOURCE[0]}")/../_boot/phoenix-ia32-generic.disk" \
+	-nographic \
+	-monitor none \
+	-netdev user,id=net0 -device rtl8139,netdev=net0 "$@"

--- a/scripts/ia32-generic.sh
+++ b/scripts/ia32-generic.sh
@@ -7,6 +7,7 @@
 #
 
 exec qemu-system-i386 \
+	-cpu pentium3 \
 	-smp 1 \
 	-serial stdio \
 	-vga cirrus \

--- a/scripts/ia32-virt.sh
+++ b/scripts/ia32-virt.sh
@@ -7,6 +7,7 @@
 #
 
 exec qemu-system-i386 \
+	-cpu pentium3 \
 	-smp 1 \
 	-serial stdio \
 	-device virtio-gpu-pci \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

1) scripts: add ia32-generic script with net setup for testing purposes
2) scripts: ia32-generic: set cpu to supported pentium3

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1) JIRA: CI-116
2) JIRA: PD-251

1) The main purpose is to enable proper lwip launching in CI process by updating qemu running command.

Now the command for running qemu (ia32-generic target) is now placed strictly in test runner:
![Screenshot from 2022-03-25 12-30-04](https://user-images.githubusercontent.com/77304431/160113898-95ed4bf4-d002-4d32-a002-b9ea393b6bdc.png)

It may be better to create the proper script in `scripts` directory that could be used by a test runner. If there is a need for change in qemu running it will be done only in the `scripts` directory (it's easier to remember about changing similar script in the same directory than changing some file in tests repository).

2) When some ca-certificates are used by openssl, sse2 instructions may be executed.
Openssl firstly checks wheather an extension exists, but when it does and isn't supported in kernel, illegal instructions are executed.
sse2 can't also be disabled (on processors with it, e. g. pentium4), even if it's not supported by the os.
That's why the cpu is set to supported one in ia32-generic scripts - pentium3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic qemu).

CI process passes with this change and https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/104 where the script is used in test runner

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
