### PR TITLE
ci: use reusable workflows in submodules

### DIFF
--- a/.github/actions/phoenix-build/action.yml
+++ b/.github/actions/phoenix-build/action.yml
@@ -18,31 +18,9 @@ inputs:
     description: 'Syspage env variable'
     default: ''
     required: false
-  # github doesn't allow array of arguments, we need to pass them one-by-one
-  param1:
-    description: 'Parameters to the main build script - 1st param'
-    default: 'clean'
-    required: false
-  param2:
-    description: 'Parameters to the main build script - 2nd param'
-    default: ''
-    required: false
-  param3:
-    description: 'Parameters to the main build script - 3rd param'
-    default: ''
-    required: false
-  param4:
-    description: 'Parameters to the main build script - 4th param'
-    default: ''
-    required: false
-  param5:
-    description: 'Parameters to the main build script - 5th param'
-    default: ''
-    required: false
-  param6:
-    description: 'Parameters to the main build script - 6th param'
-    default: ''
-    required: false
+  params:
+    description: 'All parameters to the main build script - as string'
+    required: true
 
 # action runner
 runs:
@@ -53,13 +31,7 @@ runs:
     TARGET: ${{ inputs.target }}
     SYSPAGE: ${{ inputs.syspage }}
   args:
-    - ${{ inputs.param1 }}
-    - ${{ inputs.param2 }}
-    - ${{ inputs.param3 }}
-    - ${{ inputs.param4 }}
-    - ${{ inputs.param5 }}
-    - ${{ inputs.param6 }}
-
+    - ${{ inputs.params }}  # note: params will be split by build.sh internally
 
 # branding
 branding:

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -1,18 +1,17 @@
 # vim:sw=2:ts=2
-name: ci
+# reusable build/test workflow for submodules
+name: ci-submodule
 
-# on events
 on:
-  push:
-    branches:
-      - master
-      - 'feature/*'
-  pull_request:
-    branches:
-      - master
-      - 'feature/*'
+  workflow_call:
+    inputs:
+      build_params:
+        type: string
+        description: "parameters to build.sh script"
+        default: 'core fs test project image'  # by default don't build ports
+        required: false
 
-# jobs
+
 jobs:
   build:
     name: build
@@ -21,35 +20,44 @@ jobs:
       build_result: ${{ steps.build.outcome }}
     strategy:
       matrix:
-        target: ['armv7a7-imx6ull', 'armv7a9-zynq7000-zedboard', 'armv7a9-zynq7000-qemu', 'armv7m7-imxrt106x', 'armv7m7-imxrt117x', 'armv7m4-stm32l4x6', 'host-pc', 'ia32-generic', 'riscv64-spike', 'riscv64-virt']
+        target: ['armv7a7-imx6ull', 'armv7a9-zynq7000', 'armv7m7-imxrt106x', 'armv7m7-imxrt117x', 'armv7m4-stm32l4x6', 'host-pc', 'ia32-generic', 'riscv64-spike', 'riscv64-virt']
         include:
           - target: 'ia32-generic'
             syspage: 'psh pc-ata uart16550'
     steps:
-      # step 1: checkout repository code inside the workspace directory of the runner
-      - name: Checkout the repository
+      # step 1: checkout phoenix-rtos-project repository code inside the workspace directory of the runner
+      - name: Checkout phoenix-rtos-project
         uses: actions/checkout@v2
         with:
+          repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
+
+      # step 2: update the submodule (recurse-sumbodules=no is needed for phoenix-rtos-lwip checkout not to fail, but it fails to update the submodule (TODO)
+      - name: Update submodule ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}
+        run: |
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/pull/*/head:refs/remotes/origin/pr/*"
+          git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
 
       # attach GCC problem matcher... might not work because of submodules... just trying
       - uses: ammaraskar/gcc-problem-matcher@master
 
-      # step 2: use our custom action to build the project
+      # step 3: use our custom action to build the project
       - name: Build
         id: build
         uses: ./.github/actions/phoenix-build
         with:
           target: ${{ matrix.target }}
           syspage: ${{ matrix.syspage }}
-          params: 'core fs test project image'
+          params: ${{ inputs.build_params }}
 
-      # step 3: tar rootfs
+      # step 4: tar rootfs
       - name: Tar rootfs
         working-directory: _fs
         run: tar -cvf ../rootfs-${{ matrix.target }}.tar ${{ matrix.target }}/root
 
-      # step 4: upload "_boot" directory and tarball of rootfs as build artifacts
+      # step 5: upload "_boot" directory and tarball of rootfs as build artifacts
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -69,10 +77,18 @@ jobs:
         target: ['host-pc', 'ia32-generic']
 
     steps:
-      - name: Checkout the repository
+      - name: Checkout phoenix-rtos-project
         uses: actions/checkout@v2
         with:
-          submodules: true
+          repository: phoenix-rtos/phoenix-rtos-project
+          submodules: recursive
+
+      - name: Update submodule ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}
+        run: |
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/pull/*/head:refs/remotes/origin/pr/*"
+          git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -89,6 +105,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
+  # runs on self-hosted runners with HW targets attached
   test-hw:
     needs: build
     name: run tests on hardware
@@ -100,10 +117,18 @@ jobs:
         target: ['armv7m7-imxrt106x',  'armv7m7-imxrt117x']
 
     steps:
-      - name: Checkout the repository
+      - name: Checkout phoenix-rtos-project
         uses: actions/checkout@v2
         with:
-          submodules: true
+          repository: phoenix-rtos/phoenix-rtos-project
+          submodules: recursive
+
+      - name: Update submodule ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}
+        run: |
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/pull/*/head:refs/remotes/origin/pr/*"
+          git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -144,3 +169,4 @@ jobs:
           # Optional whether this connection use TLS (default is true if server_port is 465)
           secure: true
           body: There is some problem with GH Actions. https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - master
       - 'feature/*'
+  workflow_call:  # reusable workflow - the same jobs in submodules
 
 jobs:
   clang-format:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 2  # current PR merge commit + 1 back
 
       - name: codespell
-        uses: plettich/action-codespell@master
+        uses: nalajcie/action-codespell@master
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review


### PR DESCRIPTION
## Description
Maintain single copy of CI submodule workflow instead of multiple ones.
Won't work without changes in `phoenix-rtos-build`.

## Motivation and Context
JIRA: CI-14

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
