### PR TITLE
zynq7000: Add optional bitstream in flash img. Change flash layout

### DIFF
--- a/_targets/build.project.armv7a9-zynq7000
+++ b/_targets/build.project.armv7a9-zynq7000
@@ -19,7 +19,13 @@ export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
 SIZE_PAGE=$((0x1000))
 PAGE_MASK=$((~(SIZE_PAGE - 1)))
 KERNEL_OFFS=$((0x11000))
-FS_OFFS=$((0x100000))
+FS_OFFS=$((0x800000))
+BS_OFFS=$((0x400000))
+if [ -f "${PROJECT_PATH}/bitstream.bin" ]; then
+	BS_SZ=$(wc -c "${PROJECT_PATH}/bitstream.bin" | cut -f1 -d" ")
+else
+	BS_SZ=0
+fi
 
 #
 # Project specific build
@@ -87,6 +93,9 @@ b_build_target() {
 
 	cp "${PREFIX_PROG_STRIPPED}plo-ram-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img" "$PREFIX_BOOT/plo-ram.img"
 	cp "${PREFIX_PROG_STRIPPED}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" "$PREFIX_BOOT/phoenix-kernel.elf"
+	if [ -f "${PROJECT_PATH}/bitstream.bin" ]; then
+		cp "${PROJECT_PATH}/bitstream.bin" "${PREFIX_BOOT}/"
+	fi
 }
 
 
@@ -119,6 +128,12 @@ b_image_target() {
 	echo "rootfs size: ${sz}KB"
 
 	PATH="$OLD_PATH"
+
+	# Add bitstream to PHOENIX_DISK
+	if [ -f "${PREFIX_BOOT}/bitstream.bin" ]; then
+		printf "Copying "${PREFIX_BOOT}/bitstream.bin" (offs="$((BS_OFFS/4096))" blocks)\n"
+		dd if="${PREFIX_BOOT}/bitstream.bin" of="$PHOENIX_DISK" bs=4096 seek=$((BS_OFFS/4096)) conv=notrunc 2>/dev/null
+	fi
 
 	# Add rootfs to PHOENIX_DISK
 	printf "Copying "$ROOTFS" (offs="$((FS_OFFS/4096))" blocks)\n"


### PR DESCRIPTION
JIRA: PP-38

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add bistream to the flash image. Create two bash variables (BS_OFFS and BS_SZ) which allow to create plo alias of bitstream on flash.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (zynq7000-zturn).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
