### PR TITLE
Use action-suggester instead of a patched reviewdog

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,32 +15,6 @@ on:
   workflow_call:  # reusable workflow - the same jobs in submodules
 
 jobs:
-  clang-format:
-    if: github.event_name == 'push'
-    name: clang-format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout current repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 3  # current PR merge commit + 1 back
-
-      - uses: reviewdog/action-setup@v1
-        if: false
-
-      # upstream reviewdog doesn't work for now, sideload our static binary
-      - name: Install reviewdog
-        run: |
-          wget http://misc.nalajcie.org/reviewdog -O /tmp/reviewdog 2>/dev/null
-          chmod +x /tmp/reviewdog
-
-      - name: clang-format
-        if: true
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git diff -U0 HEAD^ | clang-format-diff-10 -p1 | /tmp/reviewdog -f=diff -f.diff.strip=0 -name=clang-format -reporter=github-check
-
   # reviewdog: use clang-format for PR review
   clang-format-pr:
     if: github.event_name == 'pull_request'
@@ -52,20 +26,12 @@ jobs:
         with:
           fetch-depth: 2  # current PR merge commit + 1 back
 
-      - uses: reviewdog/action-setup@v1
-        if: false
-
-      # upstream reviewdog doesn't work for now, sideload our static binary
-      - name: Install reviewdog
-        run: |
-          wget http://misc.nalajcie.org/reviewdog -O /tmp/reviewdog 2>/dev/null
-          chmod +x /tmp/reviewdog
-
-      - name: clang-format
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git diff -U0 HEAD^ | clang-format-diff-10 -p1 | /tmp/reviewdog -f=diff -f.diff.strip=0 -name=clang-format-pr -reporter=github-pr-review -fail-on-error
+      - run: git diff -U0 HEAD^ | clang-format-diff-10 -p1 | patch -p0
+      - name: clang-format-diff
+        uses: reviewdog/action-suggester@v1
+        with:
+            tool_name: clang-format-diff
+            fail_on_error: true
 
 
   # reviewdog: codespell for PRs only


### PR DESCRIPTION
Remove clang-format from the "push" event. Annotations
do not support suggestions, so there is no sense to apply
clang-format directly to commits.

Use action-suggester instead of a patched reviewdog.


poc https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/116
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
