### PR TITLE
_targets/riscv64-generic: generate phoenix.disk image artifact

### DIFF
--- a/_targets/build.project.riscv64-generic
+++ b/_targets/build.project.riscv64-generic
@@ -143,6 +143,18 @@ b_image_target() {
 	size=$((size * 150 / 100))
 	echo "rootfs size: $size"
 	genext2fs -b $size -d "$PREFIX_ROOTFS" "$ROOTFS"
+
+	# Create disk image
+	PHOENIX_DISK="$PREFIX_BOOT/phoenix.disk"
+	rm -f "$PHOENIX_DISK"
+
+	# Add kernel to PHOENIX_DISK
+	printf "Copying "$PREFIX_BOOT/phoenix-kernel.img" (offs=0 blocks)\n"
+	dd if="$PREFIX_BOOT/phoenix-kernel.img" of="$PHOENIX_DISK" bs=512 conv=notrunc 2>/dev/null
+
+	# Add rootfs to PHOENIX_DISK
+	printf "Copying "$ROOTFS" (offs="$OFFS_ROOTFS" blocks)\n"
+	dd if="$ROOTFS" of="$PHOENIX_DISK" bs=512 seek="$OFFS_ROOTFS" conv=notrunc 2>/dev/null
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added `phoenix.disk` image as image build artifact. Required by qemu startup script.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: RTOS-201](https://jira.phoenix-rtos.com/browse/RTOS-201)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: riscv64-generic-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
