### PR TITLE
build.project: restore sourcing target file

### DIFF
--- a/_projects/armv7a7-imx6ull-evk/build.project
+++ b/_projects/armv7a7-imx6ull-evk/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.armv7a7-imx6ull"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/armv7a9-zynq7000-qemu/build.project
+++ b/_projects/armv7a9-zynq7000-qemu/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.armv7a9-zynq7000"
 
 # No networking
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"

--- a/_projects/armv7a9-zynq7000-zedboard/build.project
+++ b/_projects/armv7a9-zynq7000-zedboard/build.project
@@ -8,8 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.armv7a9-zynq7000"
-
 
 # TODO: current implementation of qspi supports only 3-bytes addressing. Cannot access the 32 MB of the flash memory.
 

--- a/_projects/armv7a9-zynq7000-zturn/build.project
+++ b/_projects/armv7a9-zynq7000-zturn/build.project
@@ -8,8 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.armv7a9-zynq7000"
-
 
 # Pre-init script is launched before user script
 PREINIT_SCRIPT=(

--- a/_projects/armv7m4-stm32l4x6-nucleo/build.project
+++ b/_projects/armv7m4-stm32l4x6-nucleo/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.armv7m4-stm32l4x6"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/armv7m7-imxrt105x-evk/build.project
+++ b/_projects/armv7m7-imxrt105x-evk/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.armv7m7-imxrt105x"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/armv7m7-imxrt106x-evk/build.project
+++ b/_projects/armv7m7-imxrt106x-evk/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.armv7m7-imxrt106x"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/armv7m7-imxrt117x-evk/build.project
+++ b/_projects/armv7m7-imxrt117x-evk/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.armv7m7-imxrt117x"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/host-generic-pc/build.project
+++ b/_projects/host-generic-pc/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.host-generic"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/ia32-generic-pc/build.project
+++ b/_projects/ia32-generic-pc/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.ia32-generic"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/ia32-generic-qemu/build.project
+++ b/_projects/ia32-generic-qemu/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.ia32-generic"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/riscv64-generic-qemu/build.project
+++ b/_projects/riscv64-generic-qemu/build.project
@@ -8,7 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.riscv64-generic"
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/riscv64-generic-spike/build.project
+++ b/_projects/riscv64-generic-spike/build.project
@@ -8,8 +8,6 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
-. "_targets/build.project.riscv64-generic"
-
 
 # Use BBL loader
 RISCV_LOADER="bbl"

--- a/build.project
+++ b/build.project
@@ -32,14 +32,21 @@ if [ -z "$TARGET_FAMILY" ] || [ -z "$TARGET_SUBFAMILY" ] || [ -z "$TARGET_PROJEC
 fi
 
 
+TARGET_FILE=$(realpath "_targets/build.project.$TARGET_FAMILY-$TARGET_SUBFAMILY")
 PROJECT_PATH=$(realpath "_projects/$TARGET")
 PROJECT_FILE="$PROJECT_PATH/build.project"
+
+if [ ! -f "$TARGET_FILE" ]; then
+	b_list_available_targets "TARGET='$TARGET' target file is unavailable"
+	exit 1
+fi
 
 if [ ! -f "$PROJECT_FILE" ]; then
 	b_list_available_targets "TARGET='$TARGET' project file is missing"
 	exit 1
 fi
 
+. "$TARGET_FILE"
 . "$PROJECT_FILE"
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Restored sourcing target file (`_targets/build.project.$TARGET_FAMILY-$TARGET_SUBFAMILY`) in the main `build.project` so that the project file (`_projects/$TARGET/build.project`) no longer needs to do this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: RTOS-202](https://jira.phoenix-rtos.com/browse/RTOS-202)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
