### PR TITLE
enable building ports within the CI process for armv7a9-zynq7000-qemu

### DIFF
--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -29,6 +29,8 @@ jobs:
         include:
           - target: 'ia32-generic-qemu'
             syspage: 'psh pc-ata uart16550'
+          - target: 'armv7a9-zynq7000-qemu'
+            additional_params: 'ports'
     steps:
       # step 1: checkout phoenix-rtos-project repository code inside the workspace directory of the runner
       - name: Checkout phoenix-rtos-project
@@ -55,7 +57,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           syspage: ${{ matrix.syspage }}
-          params: ${{ inputs.build_params }}
+          params: ${{ inputs.build_params }} ${{ matrix.additional_params }}
 
       # step 4: tar rootfs
       - name: Tar rootfs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         include:
           - target: 'ia32-generic-qemu'
             syspage: 'psh pc-ata uart16550'
+          - target: 'armv7a9-zynq7000-qemu'
+            additional_params: 'ports'
     steps:
       # step 1: checkout repository code inside the workspace directory of the runner
       - name: Checkout the repository
@@ -42,7 +44,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           syspage: ${{ matrix.syspage }}
-          params: 'core fs test project image'
+          params: core fs test project image ${{ matrix.additional_params }}
 
       # step 3: tar rootfs
       - name: Tar rootfs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- enable building ports within the CI process for armv7a9-zynq7000-qemu

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - `armv7a9-zynq7000-qemu` target now runs the busybox ash on startup. To make running tests in CI possible busybox port has to be built.

 - JIRA: PD-291

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
