### PR TITLE
build.common: Allow bankswitch for firmware upgrade

### DIFF
--- a/_targets/build.common
+++ b/_targets/build.common
@@ -98,6 +98,7 @@ b_mkscript_user() {
 # Optional variables used for remote firmware upgrade:
 # - NAME_USER2_SCRIPT - name of the secondary user script
 # - OFFS_USER2_SCRIPT - offset of the secondary user script
+# - BANKSWITCH - indicates if bankswitch command should be emitted
 b_mkscript_preinit() {
 	mkdir -p "$PREFIX_BUILD/plo/"
 
@@ -111,6 +112,9 @@ b_mkscript_preinit() {
 
 		printf "alias %s 0x%x 0x%x\n" "$NAME_USER_SCRIPT" "$OFFS_USER_SCRIPT" "$((KERNEL_OFFS - OFFS_USER_SCRIPT))"
 		printf "call %s %s %08x\n" "$BOOT_DEVICE" "$NAME_USER_SCRIPT" "$MAGIC_USER_SCRIPT"
+		if [ ! -z ${BANKSWITCH} ]; then
+			printf "bankswitch\n"
+		fi
 		if [ ! -z ${NAME_USER2_SCRIPT} ]; then
 			printf "alias %s 0x%x 0x%x\n" "$NAME_USER2_SCRIPT" "$OFFS_USER2_SCRIPT" "$((KERNEL_OFFS - OFFS_USER_SCRIPT))"
 			printf "call %s %s %08x\n" "$BOOT_DEVICE" "$NAME_USER2_SCRIPT" "$MAGIC_USER_SCRIPT"


### PR DESCRIPTION
JIRA: SKAL-561

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For armv7m4-stm32l4x6 targets we would like to do bankswitch on firmware upgrade to remap flash banks. This addition allows common scripts to emit those command for plo preinit scritp by defining BAKSWITCH variable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m4-stm32l4x6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
