### PR TITLE
projects/ia32-generic & riscv64: add UART16550 configuration to board_config.h

### DIFF
--- a/_projects/ia32-generic-pc/board_config.h
+++ b/_projects/ia32-generic-pc/board_config.h
@@ -14,4 +14,8 @@
 #ifndef _BOARD_CONFIG_H_
 #define _BOARD_CONFIG_H_
 
+/* UART16550 configuration */
+#define UART16550_CONSOLE  0
+#define UART16550_BAUDRATE 115200
+
 #endif

--- a/_projects/ia32-generic-qemu/board_config.h
+++ b/_projects/ia32-generic-qemu/board_config.h
@@ -14,4 +14,8 @@
 #ifndef _BOARD_CONFIG_H_
 #define _BOARD_CONFIG_H_
 
+/* UART16550 configuration */
+#define UART16550_CONSOLE  0
+#define UART16550_BAUDRATE 115200
+
 #endif

--- a/_projects/riscv64-generic-qemu/board_config.h
+++ b/_projects/riscv64-generic-qemu/board_config.h
@@ -14,4 +14,8 @@
 #ifndef _BOARD_CONFIG_H_
 #define _BOARD_CONFIG_H_
 
+/* UART16550 configuration */
+#define UART16550_CONSOLE  0
+#define UART16550_BAUDRATE 115200
+
 #endif

--- a/_projects/riscv64-generic-spike/board_config.h
+++ b/_projects/riscv64-generic-spike/board_config.h
@@ -14,4 +14,8 @@
 #ifndef _BOARD_CONFIG_H_
 #define _BOARD_CONFIG_H_
 
+/* UART16550 configuration */
+#define UART16550_CONSOLE  0
+#define UART16550_BAUDRATE 115200
+
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This changes need additional PR in `phoenix-rtos-devices` to work properly.
PP-82

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`uart16550` is used by zynq7000 and either baudrate and console have to be configurable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
