### PR TITLE
ci: switch to node16 actions due to GH deprecating node12

### DIFF
--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # step 1 : checkout submodule
       - name: Checkout submodule
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -55,7 +55,7 @@ jobs:
           rm -rf ${{ github.event.repository.name }}
           ln -s ../.. ${{ github.event.repository.name }}
 
-      # attach GCC problem matcher... might not work because of submodules... just trying
+      # attach GCC problem matcher - will pin problems to files only in current submodule
       - uses: ammaraskar/gcc-problem-matcher@master
 
       # step 3: use our custom action to build the project
@@ -75,7 +75,7 @@ jobs:
 
       # step 5: upload project boot directory and tarball of rootfs as build artifacts
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: phoenix-rtos-${{ matrix.target }}
           path: |
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout phoenix-rtos-project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
@@ -107,7 +107,7 @@ jobs:
           git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout phoenix-rtos-project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
@@ -147,7 +147,7 @@ jobs:
           git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: phoenix-rtos-${{ matrix.target }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
     steps:
       # step 1: checkout repository code inside the workspace directory of the runner
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      # attach GCC problem matcher... might not work because of submodules... just trying
+      # attach GCC problem matcher - will pin problems to files only in current submodule
       - uses: ammaraskar/gcc-problem-matcher@master
 
       # step 2: use our custom action to build the project
@@ -53,7 +53,7 @@ jobs:
 
       # step 4: upload project boot directory and tarball of rootfs as build artifacts
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: phoenix-rtos-${{ matrix.target }}
           path: |
@@ -72,12 +72,12 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -103,12 +103,12 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: phoenix-rtos-${{ matrix.target }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 3  # current PR merge commit + 1 back
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2  # current PR merge commit + 1 back
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2  # current PR merge commit + 1 back
 
@@ -92,7 +92,7 @@ jobs:
     name: shellcheck-pr
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
JIRA: CI-151

<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove extra warnings from CI
![image](https://user-images.githubusercontent.com/3939983/195307058-c7e1fcc3-b324-47a9-9021-c666cabd4450.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
