### PR TITLE
_targets/zynq7000: modify jffs2 image, add cleanmarkers and padding

### DIFF
--- a/_projects/armv7a9-zynq7000-qemu/build.project
+++ b/_projects/armv7a9-zynq7000-qemu/build.project
@@ -9,7 +9,9 @@
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
 # bitstream is not used in qemu, FS_OFFS is changed from 0x800000 to 0x400000 to provide more memory for rootfs
-FS_OFFS=$((0x400000))
+export FS_OFFS=$((0x400000))
+export FS_SZ=$((0xc00000))
+export FS_WRITE_CLEANMARKERS=y
 
 # No networking
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
@@ -33,7 +35,7 @@ USER_SCRIPT=(
 	"app ${BOOT_DEVICE} -x dummyfs;-N;devfs;-D ddr ddr"
 	"app ${BOOT_DEVICE} -x zynq7000-uart ddr ddr"
 	"app ${BOOT_DEVICE} -x psh;-i;/etc/rc.psh ddr ddr"
-	"app ${BOOT_DEVICE} -x zynq7000-flash;-r;/dev/mtd0:${FS_OFFS}:0xc00000:jffs2 ddr ddr"
+	"app ${BOOT_DEVICE} -x zynq7000-flash;-r;/dev/mtd0:${FS_OFFS}:${FS_SZ}:jffs2 ddr ddr"
 	"go!")
 
 

--- a/_projects/armv7a9-zynq7000-zedboard/build.project
+++ b/_projects/armv7a9-zynq7000-zedboard/build.project
@@ -12,10 +12,11 @@
 # Example of the NOR flash memory layout for Spansion s25fl256s1 (32 MB) placed on Zedboard
 #    region 1 <0:0x1ffff>    #    region 2 <0x20000:1xFFDFFFF>    #
 #          /dev/mtd0         #              /dev/mtd1           #
+export FS_SZ=$((0x1000000))
+export FS_WRITE_CLEANMARKERS=n
 
 # No networking
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
-
 
 # Pre-init script is launched before user script
 PREINIT_SCRIPT=(
@@ -36,7 +37,7 @@ USER_SCRIPT=(
 	"app ${BOOT_DEVICE} -x dummyfs;-N;devfs;-D ddr ddr"
 	"app ${BOOT_DEVICE} -x zynq7000-uart ddr ddr"
 	"app ${BOOT_DEVICE} -x psh;-i;/etc/rc.psh ddr ddr"
-	"app ${BOOT_DEVICE} -x zynq7000-flash;-r;/dev/mtd1:$((FS_OFFS-0x20000)):0x1000000:jffs2;-p;/dev/mtd1:0x1800000:0x4e0000 ddr ddr"
+	"app ${BOOT_DEVICE} -x zynq7000-flash;-r;/dev/mtd1:$((FS_OFFS-0x20000)):${FS_SZ}:jffs2;-p;/dev/mtd1:0x1800000:0x4e0000 ddr ddr"
 	"go!")
 
 

--- a/_projects/armv7a9-zynq7000-zturn/build.project
+++ b/_projects/armv7a9-zynq7000-zturn/build.project
@@ -8,6 +8,9 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
+export FS_SZ=$((0x800000))
+export FS_WRITE_CLEANMARKERS=n
+
 # No networking
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
 
@@ -30,7 +33,7 @@ USER_SCRIPT=(
 	"app ${BOOT_DEVICE} -x dummyfs;-N;devfs;-D ddr ddr"
 	"app ${BOOT_DEVICE} -x zynq7000-uart ddr ddr"
 	"app ${BOOT_DEVICE} -x psh;-i;/etc/rc.psh ddr ddr"
-	"app ${BOOT_DEVICE} -x zynq7000-flash;-r;/dev/mtd0:${FS_OFFS}:0x800000:jffs2; ddr ddr"
+	"app ${BOOT_DEVICE} -x zynq7000-flash;-r;/dev/mtd0:${FS_OFFS}:${FS_SZ}:jffs2; ddr ddr"
 	"go!")
 
 

--- a/_targets/build.project.armv7a9-zynq7000
+++ b/_targets/build.project.armv7a9-zynq7000
@@ -96,11 +96,44 @@ b_build_target() {
 }
 
 
+b_write_cleanmarkers() {
+	local rootfs_file="$1"
+	local erase_sz="$2"
+	local part_sz="$3"
+
+	# 2 B : magic
+	# 2 B : node type
+	# 4 B : total len
+	# 4 B : crc
+	local cleanmarker="\x85\x19\x03\x20\x10\x00\x00\x00\x96\x58\xd1\xfe"
+
+	local rootfs_sz=$(du -b "$rootfs_file" | awk '{ print $1 }')
+
+	[ "$((rootfs_sz % erase_sz))" -ne "0" ] && b_die "ROOT FS size is not aligned to block size!"
+
+	local blocks_cnt=$(((part_sz - rootfs_sz) / erase_sz))
+	local offs_id=$((rootfs_sz / erase_sz))
+
+	# create single erase block
+	dd if=/dev/zero bs="$erase_sz" count=1 2>/dev/null | tr "\000" "\377" > "$PREFIX_BUILD/erase_block.bin"
+	echo -en "$cleanmarker" | dd of="$PREFIX_BUILD/erase_block.bin" conv=notrunc 2>/dev/null
+
+	# write erase blocks with cleanmarkers into rootfs file
+	for block_idx in $(seq 0 $((blocks_cnt - 1))); do
+		dd if="$PREFIX_BUILD/erase_block.bin" bs="$erase_sz" count=1 seek=$((offs_id + block_idx)) of="$rootfs_file" 2>/dev/null
+	done
+}
+
+
 b_image_target() {
 	b_mkscript_user "${USER_SCRIPT[@]}"
 	b_prod_image
 	# FIXME: DEV_USER_SCRIPT is unset here - can't build dev image
 	#b_dev_image
+
+	# Function needs external variables to be defined in a project file:
+	: "${FS_SZ:?variable unset}"                   # root filesystem size
+	: "${FS_WRITE_CLEANMARKERS:?variable unset}"   # define writing cleanmarkers to final image
 
 	b_log "Creating rootfs"
 	# !!! NOTE: For non-standard NOR flash memories, erase_sz & page_sz should be changed..
@@ -113,14 +146,14 @@ b_image_target() {
 	PATH="$(pwd)/_build/host-generic-pc/prog/:$PATH"
 	ROOTFS="$PREFIX_BOOT/rootfs.jffs2"
 
-	mkfs.jffs2 -U -m none -e $erase_sz -s $page_sz -n -r "$PREFIX_ROOTFS"/ -o "$ROOTFS"
-	if sumtool -e $erase_sz -i "$ROOTFS" -o "$ROOTFS.tmp" 2> /dev/null; then
-		echo "JFFS2 Summary nodes created"
-		mv "$ROOTFS.tmp" "$ROOTFS"
-	fi
+	# Create jffs2 image with padding at the end of the final erase block
+	mkfs.jffs2 -U -c 12 -m none -e $erase_sz -s $page_sz -n -r "$PREFIX_ROOTFS"/ -o "$ROOTFS" -p
 
 	sz=$(du -k "$ROOTFS" | awk '{ print $1 }')
 	echo "rootfs size: ${sz}KB"
+
+	# Write cleanmarkers to the rootfs partition
+	[ "${FS_WRITE_CLEANMARKERS}" = "y" ] && b_write_cleanmarkers "$ROOTFS" "$erase_sz" "$FS_SZ"
 
 	PATH="$OLD_PATH"
 
@@ -133,7 +166,6 @@ b_image_target() {
 	# Add rootfs to PHOENIX_DISK
 	printf "Copying "$ROOTFS" (offs="$((FS_OFFS/4096))" blocks)\n"
 	dd if="$ROOTFS" of="$PHOENIX_DISK" bs=4096 seek=$((FS_OFFS/4096)) conv=notrunc 2>/dev/null
-	truncate -s 16M "$PHOENIX_DISK" 2>/dev/null
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change decrease time startup of the system with rootfs.
If the file contains 0xff in empty spaces and cleanmarkers, the jffs2 performs less read operation at the begining.
    
details:
    - writing cleanmarkers is added as an option
    - jff2 image contains padding at the end of the final erase block

RTOS-269

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (zedboard, zynq7000-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
