### PR TITLE
build.common: pass not aligned sizes to plo script

### DIFF
--- a/_targets/build.common
+++ b/_targets/build.common
@@ -59,9 +59,9 @@ b_mkscript_user() {
 					fi
 
 					PROGS+=("$name")
-					psz=$((($(wc -c < "${PREFIX_PROG_STRIPPED}$name") + SIZE_PAGE - 1) & PAGE_MASK))
+					psz=$(wc -c < "${PREFIX_PROG_STRIPPED}$name")
 					printf "alias %s 0x%x 0x%x\n" "$name" "$poffs" "$psz"
-					((poffs+=psz))
+					((poffs+=(psz + SIZE_PAGE - 1) & PAGE_MASK))
 					printf "%s\n" "$cmd";;
 
 				kernel)


### PR DESCRIPTION
JIRA: SKAL-681

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change causes that elf aliases are stored in plo script without allignment. In plo app command calls syspage_entryAdd with SIZE_PAGE. alignment, so loaded  application shouldn't be placed in map holes.

Result of plo "map" cmd before and after change on armv7mr-stm32l4x6-nucleo:

Before:
```
(plo)% map                                                                      
ID   NAME     START          END            ATTR
0    flash0   0x08000000     0x08080000     rx
              0x0800d000     0x0801c400   - allocated
              0x0801c400     0x08027400   - allocated
              0x08027400     0x0803e600   - allocated
              -------------------------
1    flash1   0x08080000     0x08100000     rx
2    ram      0x20000000     0x20050000     rwx
              0x20000000     0x20001200   - allocated
              0x20010000     0x20010410   - temp
              0x20010410     0x20015c1c   - temp
              0x20015c1c     0x20017280   - temp
              0x20017288     0x200172d8   - temp
              0x200172d8     0x200175a4   - temp
              0x200175a4     0x20017680   - temp
              0x20017680     0x20018f64   - temp
              0x20019000     0x2001a000   - reserved
              0x2001a000     0x2001b000   - temp
              -------------------------
```

After:
```
(plo)% map
ID   NAME     START          END            ATTR
0    flash0   0x08000000     0x08080000     rx
              0x0800d000     0x0801c400   - allocated
              0x0801c400     0x080273a4   - allocated
              0x08027400     0x0803e4d4   - allocated
              -------------------------
1    flash1   0x08080000     0x08100000     rx
2    ram      0x20000000     0x20050000     rwx
              0x20000000     0x20001200   - allocated
              0x20010000     0x20010410   - temp
              0x20010410     0x20015c1c   - temp
              0x20015c1c     0x20017280   - temp
              0x20017288     0x200172d8   - temp
              0x200172d8     0x200175a4   - temp
              0x200175a4     0x20017680   - temp
              0x20017680     0x20018f64   - temp
              0x20019000     0x2001a000   - reserved
              0x2001a000     0x2001b000   - temp
              -------------------------
```

Please note that intentionally kernel map is not touched. It invokes separate mechanism on targets with usage of cmd kernel and cmd kernelimg so it require further analysis. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required to displaying syspage progs in dummyfs /syspage dir with real binary size. 

Before:
```
(psh)% ls -al /syspage/
drw-rw-rw- 2 --- ---    19 Jan 1 00:00 .
drw-rw-rw- 6 --- ---    13 Jan 1 00:00 ..
-rwxrwxr-x 1 --- --- 94720 Jan 1 00:00 psh
-rwxrwxr-x 1 --- --- 45056 Jan 1 00:00 stm32l4-multi
```

After:
```
(psh)% ls -al /syspage/
drw-rw-rw- 2 --- ---    19 Jan 1 00:00 .
drw-rw-rw- 6 --- ---    13 Jan 1 00:00 ..
-rwxrwxr-x 1 --- --- 94420 Jan 1 00:00 psh
-rwxrwxr-x 1 --- --- 44964 Jan 1 00:00 stm32l4-multi
````

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
If some tools basing on alignment of binary, then it shouldn't and that tools need to be fixed

I would be happy if we could confirm that all use cases still works with that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7mr-stm32l4x6-nucleo, ia32-generic-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
