### PR TITLE
ci: upgrade to clang-format-12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,10 +36,11 @@ jobs:
 
       - name: clang-format
         if: true
+        shell: bash  # will enforce -o pipefail
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git diff -U0 HEAD^ | clang-format-diff-10 -p1 | /tmp/reviewdog -f=diff -f.diff.strip=0 -name=clang-format -reporter=github-check
+          git diff -U0 HEAD^ | clang-format-diff-12 -p1 | /tmp/reviewdog -f=diff -f.diff.strip=0 -name=clang-format -reporter=github-check
 
   # reviewdog: use clang-format for PR review
   clang-format-pr:
@@ -62,10 +63,11 @@ jobs:
           chmod +x /tmp/reviewdog
 
       - name: clang-format
+        shell: bash  # will enforce -o pipefail
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git diff -U0 HEAD^ | clang-format-diff-10 -p1 | /tmp/reviewdog -f=diff -f.diff.strip=0 -name=clang-format-pr -reporter=github-pr-review -fail-on-error
+          git diff -U0 HEAD^ | clang-format-diff-12 -p1 | /tmp/reviewdog -f=diff -f.diff.strip=0 -name=clang-format-pr -reporter=github-pr-review -fail-on-error
 
 
   # reviewdog: codespell for PRs only


### PR DESCRIPTION
GA ubuntu-latest image was upgraded to 22.04 LTS, clang-format-diff-10 is no longer present.

JIRA: CI-159

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
