### PR TITLE
_projects: add support for disabling urandom file in posixsrv on imx6ull

### DIFF
--- a/_projects/armv7a7-imx6ull-evk/build.project
+++ b/_projects/armv7a7-imx6ull-evk/build.project
@@ -8,6 +8,8 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
+# turn on/off "urandom" file in posixsrv
+export POSIXSRV_PRNG=y
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add a special variable `POSIXSRV_PRNG` which lets disable PRNG (`/dev/urandom` file) provided by posixsrv.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work:
- https://github.com/phoenix-rtos/phoenix-rtos-posixsrv/pull/17
- [ ] I will merge this PR by myself when appropriate.
