### PR TITLE
ia32-qemu: don't build Azure SDK by defult

### DIFF
--- a/_projects/ia32-generic-qemu/build.project
+++ b/_projects/ia32-generic-qemu/build.project
@@ -13,7 +13,7 @@
 # Ports configuration - additional to the one from _targets
 #
 export PORTS_MBEDTLS=y
-export PORTS_AZURE_SDK=y
+export PORTS_AZURE_SDK=n # FIXME: requires port to macos
 
 
 b_image_project () {


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->
Don't build Azure SDK by default until it can be built on macos.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: ia32-generic-qemu/macos host

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
