### PR TITLE
TMP: print cpp include paths

### DIFF
--- a/_user/hellocpp/Makefile
+++ b/_user/hellocpp/Makefile
@@ -6,5 +6,7 @@
 
 NAME := hellocpp
 LOCAL_SRCS := main.cpp
+LOCAL_CXXFLAGS := -Wp,-v
+LOCAL_CFLAGS := -Wp,-v
 
 include $(binary.mk)


### PR DESCRIPTION
Ignore, only checking