### PR TITLE
_targets: switch to {cross}readelf

### DIFF
--- a/_targets/build.common
+++ b/_targets/build.common
@@ -70,10 +70,11 @@ b_mkscript_user() {
 
 				kernelimg)
 					printf "alias %s 0x%x 0x%x\n" "${KERNEL_FILE}" "$KERNEL_OFFS" "$ksz"
-					tbeg=$(${CROSS}readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "R E" | awk '{ print $3 }')
-					tsz=$(${CROSS}readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "R E" | awk '{ print $6 }')
-					dbeg=$(${CROSS}readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "RW" | awk '{ print $3 }')
-					dsz=$(${CROSS}readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "RW" | awk '{ print $6 }')
+					fn="${PREFIX_PROG_STRIPPED}$KERNEL_ELF"
+					tbeg=$(${CROSS}readelf -l "$fn" | awk '/R E/ { print $3 }')
+					tsz=$(${CROSS}readelf -l "$fn" | awk '/R E/ { print $6 }')
+					dbeg=$(${CROSS}readelf -l "$fn" | awk '/RW/ { print $3 }')
+					dsz=$(${CROSS}readelf -l "$fn" | awk '/RW/ { print $6 }')
 					tsz=$(((tsz + SIZE_PAGE - 1) & PAGE_MASK))
 					dsz=$(((dsz + SIZE_PAGE - 1) & PAGE_MASK))
 					printf "%s %s %x %x %x %x\n" "$cmd" "${KERNEL_FILE}" $((tbeg)) $((tsz)) $((dbeg)) $((dsz));;

--- a/_targets/build.common
+++ b/_targets/build.common
@@ -70,10 +70,10 @@ b_mkscript_user() {
 
 				kernelimg)
 					printf "alias %s 0x%x 0x%x\n" "${KERNEL_FILE}" "$KERNEL_OFFS" "$ksz"
-					tbeg=$(readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "R E" | awk '{ print $3 }')
-					tsz=$(readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "R E" | awk '{ print $6 }')
-					dbeg=$(readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "RW" | awk '{ print $3 }')
-					dsz=$(readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "RW" | awk '{ print $6 }')
+					tbeg=$(${CROSS}readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "R E" | awk '{ print $3 }')
+					tsz=$(${CROSS}readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "R E" | awk '{ print $6 }')
+					dbeg=$(${CROSS}readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "RW" | awk '{ print $3 }')
+					dsz=$(${CROSS}readelf -l "${PREFIX_PROG_STRIPPED}$KERNEL_ELF" | grep "RW" | awk '{ print $6 }')
 					tsz=$(((tsz + SIZE_PAGE - 1) & PAGE_MASK))
 					dsz=$(((dsz + SIZE_PAGE - 1) & PAGE_MASK))
 					printf "%s %s %x %x %x %x\n" "$cmd" "${KERNEL_FILE}" $((tbeg)) $((tsz)) $((dbeg)) $((dsz));;

--- a/_targets/build.project.armv7a7-imx6ull
+++ b/_targets/build.project.armv7a7-imx6ull
@@ -107,9 +107,9 @@ b_syspage_gen() {
 	img="$1"
 	uscript="$2"
 
-	vectors=$(readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "init_vectors" | awk '{ printf("0x%s", $2) }')
-	syspage=$(readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "syspage_data" | awk '{ printf("0x%s", $2) }')
-	plugin=$(readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "plugin_ivt" | awk '{ printf("0x%s", $2) }')
+	vectors=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "init_vectors" | awk '{ printf("0x%s", $2) }')
+	syspage=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "syspage_data" | awk '{ printf("0x%s", $2) }')
+	plugin=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "plugin_ivt" | awk '{ printf("0x%s", $2) }')
 
 	addr=$((syspage-vectors))
 	sz=$((plugin-syspage))

--- a/_targets/build.project.armv7a7-imx6ull
+++ b/_targets/build.project.armv7a7-imx6ull
@@ -107,9 +107,10 @@ b_syspage_gen() {
 	img="$1"
 	uscript="$2"
 
-	vectors=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "init_vectors" | awk '{ printf("0x%s", $2) }')
-	syspage=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "syspage_data" | awk '{ printf("0x%s", $2) }')
-	plugin=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "plugin_ivt" | awk '{ printf("0x%s", $2) }')
+	fn="${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf"
+	vectors=$(${CROSS}readelf -s "$fn" | awk '/init_vectors/ { printf("0x%s", $2) }')
+	syspage=$(${CROSS}readelf -s "$fn" | awk '/syspage_data/ { printf("0x%s", $2) }')
+	plugin=$(${CROSS}readelf -s "$fn" | awk '/plugin_ivt/ { printf("0x%s", $2) }')
 
 	addr=$((syspage-vectors))
 	sz=$((plugin-syspage))

--- a/_targets/build.project.riscv64-generic
+++ b/_targets/build.project.riscv64-generic
@@ -78,9 +78,9 @@ b_syspage_gen() {
 	img="$1"
 	uscript="$2"
 
-	start=$(readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_start\b" | awk '{ printf("0x%s", $2) }')
-	syspage=$(readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_syspage_data\b" | awk '{ printf("0x%s", $2) }')
-	syspage_end=$(readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_syspage_data_end\b" | awk '{ printf("0x%s", $2) }')
+	start=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_start\b" | awk '{ printf("0x%s", $2) }')
+	syspage=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_syspage_data\b" | awk '{ printf("0x%s", $2) }')
+	syspage_end=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_syspage_data_end\b" | awk '{ printf("0x%s", $2) }')
 
 	addr=$((syspage-start))
 	sz=$((syspage_end-syspage))

--- a/_targets/build.project.riscv64-generic
+++ b/_targets/build.project.riscv64-generic
@@ -78,9 +78,10 @@ b_syspage_gen() {
 	img="$1"
 	uscript="$2"
 
-	start=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_start\b" | awk '{ printf("0x%s", $2) }')
-	syspage=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_syspage_data\b" | awk '{ printf("0x%s", $2) }')
-	syspage_end=$(${CROSS}readelf -s "${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf" | grep "\b_syspage_data_end\b" | awk '{ printf("0x%s", $2) }')
+	fn="${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf"
+	start=$(${CROSS}readelf -s "$fn" | awk '/_start$/ { printf("0x%s", $2) }')
+	syspage=$(${CROSS}readelf -s "$fn" | awk '/syspage_data$/ { printf("0x%s", $2) }')
+	syspage_end=$(${CROSS}readelf -s "$fn" | awk '/syspage_data_end$/ { printf("0x%s", $2) }')
 
 	addr=$((syspage-start))
 	sz=$((syspage_end-syspage))


### PR DESCRIPTION
It's done to avoid using host readelf, which may be incompatible (especially on macOS) with gcc version currently supported on Phoenix-RTOS.

JIRA: CI-332

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (building those targets on macOS).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
