### PR TITLE
build: remove TOPDIR usage

### DIFF
--- a/_targets/build.project.riscv64-generic
+++ b/_targets/build.project.riscv64-generic
@@ -116,7 +116,7 @@ b_build_target() {
 		mkdir -p "$BBL_BUILD_DIR"
 		pushd "$BBL_BUILD_DIR" > /dev/null || exit 1
 			if [ ! -f "$BBL_BUILD_DIR/stamp.configured" ]; then
-				"$TOPDIR/riscv/riscv-pk/configure" --host="${CROSS%?}" --with-payload="$PREFIX_BOOT/phoenix-kernel.img" --disable-fp-emulation
+				"$PREFIX_PROJECT/riscv/riscv-pk/configure" --host="${CROSS%?}" --with-payload="$PREFIX_BOOT/phoenix-kernel.img" --disable-fp-emulation
 				touch "$BBL_BUILD_DIR/stamp.configured"
 			fi
 
@@ -125,7 +125,7 @@ b_build_target() {
 
 		cp "$BBL_BUILD_DIR/bbl" "$PREFIX_BOOT/phoenix.bbl"
 	elif [ "$RISCV_LOADER" = "opensbi" ]; then
-		(cd "$TOPDIR/riscv/opensbi/" && make O="$OSBI_BUILD_DIR" CROSS_COMPILE="$CROSS" PLATFORM=generic FW_PAYLOAD_PATH="$PREFIX_BOOT/phoenix-kernel.img")
+		(cd "$PREFIX_PROJECT/riscv/opensbi/" && make O="$OSBI_BUILD_DIR" CROSS_COMPILE="$CROSS" PLATFORM=generic FW_PAYLOAD_PATH="$PREFIX_BOOT/phoenix-kernel.img")
 
 		cp "$OSBI_BUILD_DIR/platform/generic/firmware/fw_payload.elf" "$PREFIX_BOOT/phoenix.osbi"
 	else

--- a/mtd-utils/build.sh
+++ b/mtd-utils/build.sh
@@ -5,8 +5,8 @@ set -e
 if [ "$(uname)" = "Darwin" ]; then
 	b_log "Building mtd-utils"
 
-	PREFIX_MTD_UTILS="${TOPDIR}/mtd-utils"
-	PREFIX_MTD_UTILS_BUILD="${TOPDIR}/_build/host-generic-pc/mtd-utils"
+	PREFIX_MTD_UTILS="${PREFIX_PROJECT}/mtd-utils"
+	PREFIX_MTD_UTILS_BUILD="${PREFIX_PROJECT}/_build/host-generic-pc/mtd-utils"
 
 	mkdir -p "$PREFIX_MTD_UTILS_BUILD"
 
@@ -23,10 +23,10 @@ if [ "$(uname)" = "Darwin" ]; then
  	fi
 
 	make mkfs.jffs2
-	
-	mkdir -p "${TOPDIR}/_build/host-generic-pc/prog"
-	mkdir -p "${TOPDIR}/_build/host-generic-pc/prog.stripped"
-	cp mkfs.jffs2 "${TOPDIR}/_build/host-generic-pc/prog/"
-	cp mkfs.jffs2 "${TOPDIR}/_build/host-generic-pc/prog.stripped/"
+
+	mkdir -p "${PREFIX_PROJECT}/_build/host-generic-pc/prog"
+	mkdir -p "${PREFIX_PROJECT}/_build/host-generic-pc/prog.stripped"
+	cp -a mkfs.jffs2 "${PREFIX_PROJECT}/_build/host-generic-pc/prog/"
+	cp -a mkfs.jffs2 "${PREFIX_PROJECT}/_build/host-generic-pc/prog.stripped/"
 	popd
 fi


### PR DESCRIPTION
JIRA: CI-334

`TOPDIR` was obsoleted in favor of `PREFIX_PROJECT`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
