### PR TITLE
targets: fix regex matching syspage sections on riscv64

### DIFF
--- a/_targets/build.project.riscv64-generic
+++ b/_targets/build.project.riscv64-generic
@@ -79,9 +79,9 @@ b_syspage_gen() {
 	uscript="$2"
 
 	fn="${PREFIX_PROG}phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf"
-	start=$(${CROSS}readelf -s "$fn" | awk '/_start$/ { printf("0x%s", $2) }')
-	syspage=$(${CROSS}readelf -s "$fn" | awk '/syspage_data$/ { printf("0x%s", $2) }')
-	syspage_end=$(${CROSS}readelf -s "$fn" | awk '/syspage_data_end$/ { printf("0x%s", $2) }')
+	start=$(${CROSS}readelf -s "$fn" | awk '/[[:blank:]]_start$/ { printf("0x%s", $2) }')
+	syspage=$(${CROSS}readelf -s "$fn" | awk '/[[:blank:]]_syspage_data$/ { printf("0x%s", $2) }')
+	syspage_end=$(${CROSS}readelf -s "$fn" | awk '/[[:blank:]]_syspage_data_end$/ { printf("0x%s", $2) }')
 
 	addr=$((syspage-start))
 	sz=$((syspage_end-syspage))

--- a/scripts/riscv64-generic-qemu.sh
+++ b/scripts/riscv64-generic-qemu.sh
@@ -27,6 +27,6 @@ exec qemu-system-riscv64 \
 	"$OPTIMG" "$(dirname "${BASH_SOURCE[0]}")/../_boot/riscv64-generic-qemu/phoenix.osbi" \
 	-serial stdio \
 	-device virtio-gpu-device \
-	-drive file="$(dirname "${BASH_SOURCE[0]}")/../_boot/riscv64-generic-qemu/phoenix.disk",cache=unsafe,if=none,id=vblk0 \
+	-drive file="$(dirname "${BASH_SOURCE[0]}")/../_boot/riscv64-generic-qemu/phoenix.disk",format=raw,cache=unsafe,if=none,id=vblk0 \
 	-device virtio-blk-device,drive=vblk0 \
 	-netdev user,id=net0 -device virtio-net-device,netdev=net0

--- a/scripts/riscv64-generic-spike.sh
+++ b/scripts/riscv64-generic-spike.sh
@@ -29,6 +29,6 @@ exec qemu-system-riscv64 \
 	"$OPTIMG" "$(dirname "${BASH_SOURCE[0]}")/../_boot/riscv64-generic-spike/phoenix.bbl" \
 	-serial stdio \
 	-device virtio-gpu-device \
-	-drive file="$(dirname "${BASH_SOURCE[0]}")/../_boot/riscv64-generic-spike/phoenix.disk",cache=unsafe,if=none,id=vblk0 \
+	-drive file="$(dirname "${BASH_SOURCE[0]}")/../_boot/riscv64-generic-spike/phoenix.disk",format=raw,cache=unsafe,if=none,id=vblk0 \
 	-device virtio-blk-device,drive=vblk0 \
 	-netdev user,id=net0 -device virtio-net-device,netdev=net0


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

The change fixes the regex incorrectly matching multiple occurrences of the section names `*_start` (should match once, `_start` exactly). The fix is to add a blank match before the section names.

With `build.sh` use `host` component  which is required to build `syspagen` (CI fails because of no `host` [component in default buld params](https://github.com/phoenix-rtos/phoenix-rtos-project/blob/master/.github/workflows/ci-project.yml#L16)?).

Update: This PR adds `host` to CI https://github.com/phoenix-rtos/phoenix-rtos-project/pull/821

JIRA: RTOS-592

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/819
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-generic-qemu`, `riscv64-generic-spike`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
