### PR TITLE
_targets: stm32l4x6: Remove exported BOARD_CONFIG

### DIFF
--- a/_targets/build.project.armv7m4-stm32l4x6
+++ b/_targets/build.project.armv7m4-stm32l4x6
@@ -11,9 +11,6 @@
 
 CROSS=arm-phoenix-
 
-# TODO: move BOARD_CONFIG defines to board_config.h
-export BOARD_CONFIG=" -DUART_CONSOLE=2 -DTTY2=1 "
-
 export BUSYBOX_CONFIG=$(realpath "busybox_config")
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
 export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="


### PR DESCRIPTION
JIRA: DEND-32

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Remove exported BOARD_CONFIG

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It overwrites board_config.h and make confusion. Not needed for internal project - rest of removal deprecated BOARD_CONFIG expoted variable removal will be performed in others commits. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
Project that use fork of phoenix-rtos-project and use BOARD_CONFIG env variable, need to be switched to board_config.h 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m4-stm32l4x6-nucleo.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/422
Updates submodules with that commit first
- [ ] I will merge this PR by myself when appropriate.
