### PR TITLE
Update submodule enabling pseudo devices

### DIFF
--- a/_projects/armv7m7-imxrt105x-evk/board_config.h
+++ b/_projects/armv7m7-imxrt105x-evk/board_config.h
@@ -14,4 +14,6 @@
 #ifndef _BOARD_CONFIG_H_
 #define _BOARD_CONFIG_H_
 
+#define PSEUDODEV 1
+
 #endif

--- a/_projects/armv7m7-imxrt106x-evk/board_config.h
+++ b/_projects/armv7m7-imxrt106x-evk/board_config.h
@@ -14,4 +14,6 @@
 #ifndef _BOARD_CONFIG_H_
 #define _BOARD_CONFIG_H_
 
+#define PSEUDODEV 1
+
 #endif

--- a/_projects/armv7m7-imxrt117x-evk/board_config.h
+++ b/_projects/armv7m7-imxrt117x-evk/board_config.h
@@ -17,4 +17,6 @@
 #define UART1        1
 #define UART_CONSOLE 1
 
+#define PSEUDODEV 1
+
 #endif

--- a/_projects/sparcv8leon3-gr716-mini/board_config.h
+++ b/_projects/sparcv8leon3-gr716-mini/board_config.h
@@ -66,5 +66,7 @@
 #define GPIO_DIR_IN  0
 #define GPIO_DIR_OUT 1
 
+#define PSEUDODEV 1
+
 
 #endif


### PR DESCRIPTION
### Enable pseudo devices

    Change enables pseudo devices in multi-driver on imxrt10xx, imxrt117x
    and sparcv8leon3-gr716-mini.
    
    Note: if posixsrv is to be used libpseudodev needs to be disabled.

    JIRA: RTOS-640


### Update submodule

    * phoenix-rtos-devices ee66265..acd572c:
      > gr716-multi: add support for pseudo devices
      > imxrt-multi: add support for pseudo devices
      > Introduce library for handling pseudo devices
      > imx6ull-uart: apply MISRA
      > libtty/lf_fifo: drop old bytes in case of overrun

    JIRA: RTOS-640