### PR TITLE
zynq7000: add SD card pins to board configs

### DIFF
--- a/_projects/armv7a9-zynq7000-qemu/board_config.h
+++ b/_projects/armv7a9-zynq7000-qemu/board_config.h
@@ -99,6 +99,16 @@
 #define QSPI_CLK  6
 #define QSPI_FCLK 8
 
+/* SD card configuration */
+#define SD_CARD_CLK -1
+#define SD_CARD_CMD -1
+#define SD_CARD_D0  -1
+#define SD_CARD_D1  -1
+#define SD_CARD_D2  -1
+#define SD_CARD_D3  -1
+#define SD_CARD_CD  -1
+#define SD_CARD_WP  -1
+
 /* GPIO bank 0 configuration */
 #define GPIO0_0  -1
 #define GPIO0_1  -1

--- a/_projects/armv7a9-zynq7000-zedboard/board_config.h
+++ b/_projects/armv7a9-zynq7000-zedboard/board_config.h
@@ -100,6 +100,16 @@
 #define QSPI_CLK  6
 #define QSPI_FCLK 8
 
+/* SD card configuration */
+#define SD_CARD_CLK 40
+#define SD_CARD_CMD 41
+#define SD_CARD_D0  42
+#define SD_CARD_D1  43
+#define SD_CARD_D2  44
+#define SD_CARD_D3  45
+#define SD_CARD_CD  47
+#define SD_CARD_WP  46
+
 /* GPIO bank 0 configuration */
 #define GPIO0_0  -1
 #define GPIO0_1  -1

--- a/_projects/armv7a9-zynq7000-zturn/board_config.h
+++ b/_projects/armv7a9-zynq7000-zturn/board_config.h
@@ -99,6 +99,16 @@
 #define QSPI_CLK  6
 #define QSPI_FCLK 8
 
+/* SD card configuration */
+#define SD_CARD_CLK 40
+#define SD_CARD_CMD 41
+#define SD_CARD_D0  42
+#define SD_CARD_D1  43
+#define SD_CARD_D2  44
+#define SD_CARD_D3  45
+#define SD_CARD_CD  46
+#define SD_CARD_WP  47 /* Always pulled low on this board */
+
 /* GPIO bank 0 configuration */
 #define GPIO0_0  -1
 #define GPIO0_1  -1


### PR DESCRIPTION
Added pin assignments for SD card slot for Zynq 7000-based platforms.

## Description
On Zedboard and Z-turn boards the pin assignments are as described in the respective board's documentation. On QEMU all pins are given a value of -1 to signal that they are not used.

## Motivation and Context
Necessary to implement SD card driver.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-qemu, armv7a9-zynq7000-zedboard, armv7a9-zynq7000-zturn

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
