### PR TITLE
ci: ensure jobs continue even if one fails

### DIFF
--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -77,7 +77,7 @@ jobs:
     outputs:
       runner_result: ${{ steps.runner.outcome }}
     strategy:
-      fail-fast: ${{ ! inputs.nightly }}
+      fail-fast: false
       matrix:
         target: ['armv7a9-zynq7000-qemu', 'host-generic-pc', 'ia32-generic-qemu', 'riscv64-generic-qemu']
 
@@ -122,7 +122,7 @@ jobs:
     outputs:
       runner_result: ${{ steps.runner.outcome }}
     strategy:
-      fail-fast: ${{ ! inputs.nightly }}
+      fail-fast: false
       matrix:
         target: ['armv7a7-imx6ull-evk', 'armv7m7-imxrt106x-evk', 'armv7m7-imxrt117x-evk', 'armv7a9-zynq7000-zedboard', 'armv7m4-stm32l4x6-nucleo']
 

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -93,6 +93,7 @@ jobs:
     outputs:
       runner_result: ${{ steps.runner.outcome }}
     strategy:
+      fail-fast: false
       matrix:
         target: ['armv7a9-zynq7000-qemu', 'host-generic-pc', 'ia32-generic-qemu', 'riscv64-generic-qemu']
 
@@ -145,6 +146,7 @@ jobs:
     outputs:
       runner_result: ${{ steps.runner.outcome }}
     strategy:
+      fail-fast: false
       matrix:
         target: ['armv7a7-imx6ull-evk', 'armv7m7-imxrt106x-evk', 'armv7m7-imxrt117x-evk', 'armv7a9-zynq7000-zedboard', 'armv7m4-stm32l4x6-nucleo']
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes shortly -->
If one of matrix jobs fails (e.g., for one specific target), the other matrix jobs will continue running and will not be cancelled
![image](https://github.com/phoenix-rtos/phoenix-rtos-project/assets/116297248/aacf6e61-4b42-4ee2-8a63-ff9bdca60e7c)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Stopping jobs on targets, even if one has failed, makes it difficult to identify errors, especially if there are intermittent issues with a particular target.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
