### PR TITLE
zynq7000: Set page size correctly in mkfs.jffs2

### DIFF
--- a/_targets/build.project.armv7a7-imx6ull
+++ b/_targets/build.project.armv7a7-imx6ull
@@ -47,7 +47,6 @@ MAGIC_USER_SCRIPT=$((0xdabaabad)) # User script magic value
 OFFS_USER_SCRIPT=$((0x0))         # Disk image user script offset (in bytes)
 OFFS_ROOTFS=$((0x1000))           # Disk image rootfs offset (in 512 byte sectors)
 ERASE_SIZE=$((64 * 4096))         # Rootfs disk erase block size (in bytes)
-SECTOR_SIZE=$((4096))             # Rootfs write sector size (in bytes)
 CLEANMARKER_SIZE=$((0))           # JFFS2 cleanmarker size (in bytes)
 
 
@@ -173,7 +172,7 @@ b_image_target() {
 		CLEANMARKER_ARG=("-c" "$CLEANMARKER_SIZE")
 	fi
 
-	mkfs.jffs2 -U "${CLEANMARKER_ARG[@]}" -l -m none -e $ERASE_SIZE -s $SECTOR_SIZE -r "$PREFIX_ROOTFS"/ -o "$ROOTFS"
+	mkfs.jffs2 -U "${CLEANMARKER_ARG[@]}" -l -m none -e $ERASE_SIZE -s $SIZE_PAGE -r "$PREFIX_ROOTFS"/ -o "$ROOTFS"
 
 	if sumtool "${CLEANMARKER_ARG[@]}" -e $ERASE_SIZE -l -i "$ROOTFS" -o "$ROOTFS.tmp" 2> /dev/null; then
 		echo "JFFS2 Summary nodes created"

--- a/_targets/build.project.armv7a9-zynq7000
+++ b/_targets/build.project.armv7a9-zynq7000
@@ -136,9 +136,8 @@ b_image_target() {
 	: "${FS_WRITE_CLEANMARKERS:?variable unset}"   # define writing cleanmarkers to final image
 
 	b_log "Creating rootfs"
-	# !!! NOTE: For non-standard NOR flash memories, erase_sz & page_sz should be changed..
+	# !!! NOTE: For non-standard NOR flash memories, erase_sz should be changed.
 	local erase_sz=$((0x10000))
-	local page_sz=$((0x100))
 
 	# FIXME: does work only on macOS, for now hackish solution based on extending PATH
 	mtd-utils/build.sh
@@ -147,7 +146,7 @@ b_image_target() {
 	ROOTFS="$PREFIX_BOOT/rootfs.jffs2"
 
 	# Create jffs2 image with padding at the end of the final erase block
-	mkfs.jffs2 -U -c 12 -m none -e $erase_sz -s $page_sz -n -r "$PREFIX_ROOTFS"/ -o "$ROOTFS" -p
+	mkfs.jffs2 -U -c 12 -m none -e $erase_sz -s $SIZE_PAGE -n -r "$PREFIX_ROOTFS"/ -o "$ROOTFS" -p
 
 	sz=$(du -k "$ROOTFS" | awk '{ print $1 }')
 	echo "rootfs size: ${sz}KB"


### PR DESCRIPTION
Changed page size parameter when building root FS for Zynq 7000 systems.

## Description
Previously the page size parameter was set to flash chip page size of 256 bytes instead of the system memory page size of 4096 bytes. Now the page size is set correctly.

## Motivation and Context
This change improves filesystem performance, especially on armv7a9-zynq7000-qemu (where filesystem mounting is now about 33% faster). Additionally, the resulting filesystem image is smaller.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-zturn armv7a9-zynq7000-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
