### PR TITLE
imx6ull: rc.psh: mute supress

### DIFF
--- a/_projects/armv7a7-imx6ull-evk/rootfs-overlay/etc/rc.psh
+++ b/_projects/armv7a7-imx6ull-evk/rootfs-overlay/etc/rc.psh
@@ -4,6 +4,8 @@ export HOME=/root
 W /bin/bind devfs /dev
 X /sbin/imx6ull-gpio
 W /sbin/dummyfs -m /var -D
+// suppressing dmesg message from lwip before execution
+X /bin/dmesg -D
 X /sbin/lwip enet:0x02188000:150:PHY:0.2:irq:-5:/dev/gpio5 enet:0x020b4000:152:no-mdio:PHY:0.1:irq:-6:/dev/gpio5
 X /bin/posixsrv
 X /bin/psh


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
JIRA: CI-393

Change cover situation when device has available Ethernet connection to startup `lwip`

## Motivation and Context
System init before suppress (With connected ):
![Screenshot from 2023-11-27 10-08-20](https://github.com/phoenix-rtos/phoenix-rtos-project/assets/49757239/280f7075-309b-4f1d-a1c1-65feba3bb29e)

System init after suppress:
![Screenshot from 2023-11-27 10-08-02](https://github.com/phoenix-rtos/phoenix-rtos-project/assets/49757239/fedf2108-2e29-449e-bf73-f25d2fc1310f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: armv7a7-imx6ull-evk.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
