### PR TITLE
ia32-generic: Mount dummyfs in /dev

### DIFF
--- a/_projects/ia32-generic-pc/rootfs-overlay/etc/rc.psh
+++ b/_projects/ia32-generic-pc/rootfs-overlay/etc/rc.psh
@@ -1,6 +1,8 @@
 :{}:
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin
 export HOME=/root
+W /bin/bind devfs /dev
 X /bin/posixsrv
 X /sbin/lwip rtl:0x18:11
+T /dev/console
 X /bin/psh

--- a/_projects/ia32-generic-qemu/rootfs-overlay/etc/rc.psh
+++ b/_projects/ia32-generic-qemu/rootfs-overlay/etc/rc.psh
@@ -1,6 +1,8 @@
 :{}:
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin
 export HOME=/root
+W /bin/bind devfs /dev
 X /bin/posixsrv
 X /sbin/lwip rtl:0x18:11
+T /dev/console
 X /bin/psh

--- a/_targets/build.project.ia32-generic
+++ b/_targets/build.project.ia32-generic
@@ -73,9 +73,10 @@ fi
 USER_SCRIPT=(
 	"wait 1000"
 	"kernel $BOOT_DEVICE"
-	"app ${BOOT_DEVICE} -x pc-ata ram ram"
-	"app ${BOOT_DEVICE} -x psh;-i;/etc/rc.psh ram ram"
+	"app ${BOOT_DEVICE} -x dummyfs;-N;devfs;-D ram ram"
 	"app ${BOOT_DEVICE} -x ${CONSOLE_APP} ram ram"
+	"app ${BOOT_DEVICE} -x psh;-i;/etc/rc.psh ram ram"
+	"app ${BOOT_DEVICE} -x pc-ata ram ram"
 	"go!"
 )
 


### PR DESCRIPTION
Use dummyfs to create `devfs` and mount it in `/dev` directory.

## Motivation and Context
With this change `devfs` can be used to access devices on ia32-generic the same way as on other platforms.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
