### PR TITLE
 ci: migrate to actions based on node20

### DIFF
--- a/.github/problem-matchers/gcc.json
+++ b/.github/problem-matchers/gcc.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc",
+            "pattern": [
+                {
+                    "regexp": "^(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -44,7 +44,8 @@ jobs:
           submodules: recursive
 
       # attach GCC problem matcher - will pin problems to files only in current submodule
-      - uses: ammaraskar/gcc-problem-matcher@master
+      - name: Add GCC problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/gcc.json"
 
       # step 2: use our custom action to build the project
       - name: Build

--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       # step 1: checkout repository code inside the workspace directory of the runner
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -63,7 +63,7 @@ jobs:
 
       # step 4: upload project boot directory and tarball of rootfs as build artifacts
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: phoenix-rtos-${{ matrix.target }}
           path: |
@@ -83,12 +83,12 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload runner results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.target }}
           path: |
@@ -128,12 +128,12 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload runner results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.target }}
           path: |
@@ -161,10 +161,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        # FIXME: download-artifact don't support downloading artifacts by wildcard, download all artifacts for now
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: test-results-*
 
       - name: Display structure of downloaded files
         run: ls -R
@@ -176,7 +176,7 @@ jobs:
           junit2html junit.xml junit.html
 
       - name: Upload Merged Unit Test Results in HTML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Merged Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -60,7 +60,8 @@ jobs:
           ln -s ../.. ${{ github.event.repository.name }}
 
       # attach GCC problem matcher - will pin problems to files only in current submodule
-      - uses: ammaraskar/gcc-problem-matcher@master
+      - name: Add GCC problem matcher
+        run: echo "::add-matcher::./.buildroot/phoenix-rtos-project/.github/problem-matchers/gcc.json"
 
       # step 3: use our custom action to build the project
       - name: Build

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # step 1 : checkout submodule
       - name: Checkout submodule
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -79,7 +79,7 @@ jobs:
 
       # step 5: upload project boot directory and tarball of rootfs as build artifacts
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: phoenix-rtos-${{ matrix.target }}
           path: |
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout phoenix-rtos-project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
@@ -112,7 +112,7 @@ jobs:
           git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload runner results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.target }}
           path: |
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: Checkout phoenix-rtos-project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
@@ -165,7 +165,7 @@ jobs:
           git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload runner results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.target }}
           path: |
@@ -193,10 +193,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        # FIXME: download-artifact don't support downloading artifacts by wildcard, download all artifacts for now
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: test-results-*
 
       - name: Display structure of downloaded files
         run: ls -R
@@ -208,7 +208,7 @@ jobs:
           junit2html junit.xml junit.html
 
       - name: Upload Merged Unit Test Results in HTML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Merged Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 3  # current PR merge commit + 1 back
 
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2  # current PR merge commit + 1 back
 
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2  # current PR merge commit + 1 back
 
@@ -93,7 +93,7 @@ jobs:
     name: shellcheck-pr
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
(do not merge with the top commit present)

## Description

- ci: use internal problem matcher for gcc
  don't depend on external GH action as it's not needed.
- ci: migrate to actions based on node20
  Needed due to node16 being EOLed.


## Motivation and Context
 JIRA: CI-398

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
