### PR TITLE
armv7a9-qemu: Adjust serial device

### DIFF
--- a/scripts/armv7a9-zynq7000-qemu-test.sh
+++ b/scripts/armv7a9-zynq7000-qemu-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Shell script for running phoenix-rtos loader on Qemu fork from Xilinx (zynq-7000)
+#
+# Copyright 2021 Phoenix Systems
+# Author: Hubert Buczynski, Damian Modzelewski
+#
+
+IMG_PLO_ZYNQ7000="$(dirname "${BASH_SOURCE[0]}")/../_boot/armv7a9-zynq7000-qemu/plo.img"
+IMG_FLASH_QEMU="$(dirname "${BASH_SOURCE[0]}")/../_boot/armv7a9-zynq7000-qemu/phoenix.disk"
+DTB_ZYNQ7000="$(dirname "${BASH_SOURCE[0]}")/../scripts/zynq7000-zc702.dtb"
+
+for FILE in "$IMG_PLO_ZYNQ7000" "$IMG_FLASH_QEMU" "$DTB_ZYNQ7000"; do
+	if [ ! -f "$FILE" ]; then
+		echo "Missing required file: $FILE"
+		exit 1
+	fi
+done
+
+exec qemu-system-aarch64 \
+	-M arm-generic-fdt-7series \
+	-dtb "$DTB_ZYNQ7000" \
+	-serial null \
+	-serial stdio \
+	-device loader,file="$IMG_PLO_ZYNQ7000" \
+	-drive file="$IMG_FLASH_QEMU",if=mtd,format=raw,index=0


### PR DESCRIPTION
JIRA: CI-397

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
In the process of creating a test that check's Control Codes, there is a problem with our QEMU setup. 
qemu-system-aarch64 with machine arm-generic-fdt-7series have multiple serials outputs. First one is responsible for VNC connection. Second one is strictly connected with emulated environment. Redirecting it to `mon:stdio` give us access to use QEMU shortcuts which they collide with our tests. Even in further use cases, this will be a problem.
Shortcuts available with serial output set on to `mon:stdio`:

![image](https://github.com/phoenix-rtos/phoenix-rtos-project/assets/49757239/e90be0d2-861a-4601-8f48-de92e4f06b24)

To minimize interference from QEMU side, we can simply redirect serial directly on stdio and solve this problem.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: armv7a9-zynq7000-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
