### PR TITLE
ci: decrease aslr entropy before testing and building on gh hosted runners

### DIFF
--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Add GCC problem matcher
         run: echo "::add-matcher::.github/problem-matchers/gcc.json"
 
+      # Issue caused by incompability between the amount of entropy bits in the specific linux kernel version (32) and ASAN (28)
+      # To be removed after updating Actions Runner Ubuntu image to the fixed version
+      # https://github.com/actions/runner-images/issues/9491
+      # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1032
+      - name: Decrease ASLR entropy due to temporary issue on gh-hosted runners
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       # step 2: use our custom action to build the project
       - name: Build
         id: build
@@ -99,6 +106,13 @@ jobs:
 
       - name: Add sanitizers problem matcher
         run: echo "::add-matcher::.github/problem-matchers/sanitizer-errors.json"
+
+      # Issue caused by incompability between the amount of entropy bits in the specific linux kernel version (32) and ASAN (28)
+      # To be removed after updating Actions Runner Ubuntu image to the fixed version
+      # https://github.com/actions/runner-images/issues/9491
+      # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1032
+      - name: Decrease ASLR entropy due to temporary issue on gh-hosted runners
+        run: sudo sysctl vm.mmap_rnd_bits=28
 
       - name: Test runner
         id: runner

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -63,6 +63,13 @@ jobs:
       - name: Add GCC problem matcher
         run: echo "::add-matcher::./.buildroot/phoenix-rtos-project/.github/problem-matchers/gcc.json"
 
+      # Issue caused by incompability between the amount of entropy bits in the specific linux kernel version (32) and ASAN (28)
+      # To be removed after updating Actions Runner Ubuntu image to the fixed version
+      # https://github.com/actions/runner-images/issues/9491
+      # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1032
+      - name: Decrease ASLR entropy due to temporary issue on gh-hosted runners
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       # step 3: use our custom action to build the project
       - name: Build
         id: build
@@ -123,6 +130,13 @@ jobs:
 
       - name: Add sanitizers problem matcher
         run: echo "::add-matcher::.github/problem-matchers/sanitizer-errors.json"
+
+      # Issue caused by incompability between the amount of entropy bits in the specific linux kernel version (32) and ASAN (28)
+      # To be removed after updating Actions Runner Ubuntu image to the fixed version
+      # https://github.com/actions/runner-images/issues/9491
+      # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1032
+      - name: Decrease ASLR entropy due to temporary issue on gh-hosted runners
+        run: sudo sysctl vm.mmap_rnd_bits=28
 
       - name: Test runner
         id: runner


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CI fails on host due to:
https://github.com/actions/runner-images/issues/9491
https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1032

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (tested a few times on CI with those changes - no errors discovered).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

*NOTE: This change is going to be active after merge to master
