### PR TITLE
_targets/build.common: add OFFS_USER_SCRIPT check

### DIFF
--- a/_targets/build.common
+++ b/_targets/build.common
@@ -229,6 +229,12 @@ b_prod_image() {
 	PHOENIX_DISK="$PREFIX_BOOT/phoenix.disk" # plo + PHOENIX_IMG
 	rm -f "$PHOENIX_IMG" "$PHOENIX_DISK"
 
+	local loadersz
+	loadersz=$(wc -c < "${PREFIX_PROG_STRIPPED}plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img")
+	if [ "$loadersz" -ge "$OFFS_USER_SCRIPT" ]; then
+		b_die "User script offset to small: $OFFS_USER_SCRIPT, loader size: $loadersz."
+	fi
+
 	sz=$(wc -c < "$PLO_SCRIPT_DIR/$NAME_USER_SCRIPT")
 	if [ "$sz" -ge "$((KERNEL_OFFS - OFFS_USER_SCRIPT))" ]; then
 		b_die "User script size too large. Please, change kernel offset or user script offset."
@@ -289,6 +295,12 @@ b_dev_image() {
 
 	b_mkscript_user "${DEV_USER_SCRIPT[@]}"
 	printf "%s\n" "${REMOTE_USER_SCRIPT[@]}" > "$REMOTE_SCRIPT_PATH"
+
+	local loadersz
+	loadersz=$(wc -c < "${PREFIX_PROG_STRIPPED}plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img")
+	if [ "$loadersz" -ge "$OFFS_USER_SCRIPT" ]; then
+		b_die "User script offset to small: $OFFS_USER_SCRIPT, loader size: $loadersz."
+	fi
 
 	sz=$(wc -c < "$PLO_SCRIPT_DIR/$NAME_USER_SCRIPT")
 	if [ "$sz" -ge "$((KERNEL_OFFS - OFFS_USER_SCRIPT))" ]; then


### PR DESCRIPTION
JIRA: RTOS-898

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Check `plo` size and `OFFS_USER_SCRIPT` to not silently overwrite `plo` in phoenix disk.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
