### PR TITLE
armv7a9-zynq7000-zedboard: fix rootfs partition offset

### DIFF
--- a/_projects/armv7a9-zynq7000-zedboard/nvm.yaml
+++ b/_projects/armv7a9-zynq7000-zedboard/nvm.yaml
@@ -10,7 +10,7 @@ flash0:
     - name: bitstr
       offs: 0x400000
     - name: rootfs
-      offs: 0x900000
+      offs: 0x800000
       size: 0x1000000
       type: jffs2
     - name: data

--- a/_projects/armv7a9-zynq7000-zedboard/user.plo.yaml
+++ b/_projects/armv7a9-zynq7000-zedboard/user.plo.yaml
@@ -15,8 +15,8 @@ contents:
     flags: EXEC
     filename: zynq7000-flash
     args:
-       - '-r;/dev/mtd1:{{ nvm.flash0.rootfs.offs - nvm.flash0.mtd1.offs }}:{{ nvm.flash0.rootfs.size }}:jffs2'
-       - '-p;/dev/mtd1:{{ nvm.flash0.data.offs   - nvm.flash0.mtd1.offs }}:{{ nvm.flash0.data.size }}'
+       - '-r;/dev/mtd1:{{ "%#x" % (nvm.flash0.rootfs.offs - nvm.flash0.mtd1.offs) }}:{{ "%#x" % nvm.flash0.rootfs.size }}:jffs2'
+       - '-p;/dev/mtd1:{{ "%#x" % (nvm.flash0.data.offs   - nvm.flash0.mtd1.offs) }}:{{ "%#x" % nvm.flash0.data.size }}'
     text_map: ddr
     data_maps: ddr
   - go!


### PR DESCRIPTION
JIRA: CI-494

<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently patrition offsets in `trunner` are hardcoded thus slightly incorrect area was cleared (last 1MB of the partition might have had random data).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
