### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,25 +5,31 @@ ColumnLimit: 0
 AlignAfterOpenBracket: DontAlign
 UseTab: ForContinuationAndIndentation
 IndentWidth: 4
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 8
+BracedInitializerIndentWidth: 4
 TabWidth: 4
 
 PointerAlignment: Right
-SpaceAfterCStyleCast: 'false'
+SpaceAfterCStyleCast: false
 BreakBeforeBraces: Stroustrup
 
-AlignConsecutiveMacros: 'true'
+AlignConsecutiveMacros:
+  Enabled: true
 AlignEscapedNewlines: DontAlign
-AlignTrailingComments: 'true'
-AllowShortBlocksOnASingleLine: 'true'
-AllowShortCaseLabelsOnASingleLine: 'true'
-AllowShortLoopsOnASingleLine: 'true'
-IndentCaseLabels: 'true'
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
+IndentCaseLabels: true
 MaxEmptyLinesToKeep: 2
-SortIncludes: 'false'
+SortIncludes: false
 SpacesBeforeTrailingComments: 2
 
 BreakBeforeBinaryOperators: None
-BreakBeforeTernaryOperators: 'false'
+BreakBeforeTernaryOperators: false
 BreakConstructorInitializers: AfterColon
+
+InsertNewlineAtEOF: true
 ...


### PR DESCRIPTION
JIRA: RTOS-946

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

As build infrastructure are updated to Ubuntu 24.04 which contain clang-format-18, some new clang-format options are introduced, that better match our coding style.

New .clang-format file contain following changes:

-  Change `ContinuationIndentWidth` from `4` to `8` and add `BracedInitializerIndentWidth` set to `4` (new in clang-format-17)
This change allow us to format multiline control statement (ifs, whiles...) with double indentation to visually distinct conditions from body. It's in our coding rules but reported as an issue by clang-format.
Downside of that change is changing rules for other multiline statements such as assignment, macros etc. Example of changes below:

```diff
@@ -189,8 +189,8 @@ void *hal_exceptionsFaultAddr(unsigned int n, exc_context_t *ctx)
        }
 
        if (status != EXC_ACCESS_SECTION && status != EXC_ACCESS_PAGE &&
-               status != EXC_PERM_SECTION && status != EXC_PERM_PAGE &&
-               status != EXC_TRANSLATION_PAGE && status != EXC_TRANSLATION_SECTION)
+                       status != EXC_PERM_SECTION && status != EXC_PERM_PAGE &&
+                       status != EXC_TRANSLATION_PAGE && status != EXC_TRANSLATION_SECTION)
                return NULL;
 
        return addr;
```

```diff
@@ -443,10 +443,10 @@ int hal_platformctl(void *ptr)
                case pctl_iopad:
                        if (data->action == pctl_set)
                                ret = _imx6ull_setIOpad(data->iopad.pad, data->iopad.hys, data->iopad.pus, data->iopad.pue,
-                                       data->iopad.pke, data->iopad.ode, data->iopad.speed, data->iopad.dse, data->iopad.sre);
+                                               data->iopad.pke, data->iopad.ode, data->iopad.speed, data->iopad.dse, data->iopad.sre);
                        else if (data->action == pctl_get)
                                ret = _imx6ull_getIOpad(data->iopad.pad, &data->iopad.hys, &data->iopad.pus, &data->iopad.pue,
-                                       &data->iopad.pke, &data->iopad.ode, &data->iopad.speed, &data->iopad.dse, &data->iopad.sre);
+                                               &data->iopad.pke, &data->iopad.ode, &data->iopad.speed, &data->iopad.dse, &data->iopad.sre);
                        break;
                case pctl_ioisel:
                        if (data->action == pctl_set)
```

```diff
@@ -38,7 +38,7 @@
 #endif
 
 #if defined(WATCHDOG) && \
-       (WATCHDOG_TIMEOUT_MS <= 0x0 || WATCHDOG_TIMEOUT_MS > (0xffffU * 256 / (LPO_CLK_FREQ_HZ / 1000)))
+               (WATCHDOG_TIMEOUT_MS <= 0x0 || WATCHDOG_TIMEOUT_MS > (0xffffU * 256 / (LPO_CLK_FREQ_HZ / 1000)))
 #error "Watchdog timeout out of bounds!"
 #endif
 ```

```diff
@@ -1571,7 +1571,7 @@ int proc_fork(void)
                /* Copy parent context to child kstack in case of signal handling on fork return */
                parent = ((process_spawn_t *)current->execdata)->parent;
                hal_memcpy(current->kstack + current->kstacksz - sizeof(cpu_context_t),
-                       parent->kstack + parent->kstacksz - sizeof(cpu_context_t), sizeof(cpu_context_t));
+                               parent->kstack + parent->kstacksz - sizeof(cpu_context_t), sizeof(cpu_context_t));
 
                hal_cpuSmpSync();
 ```

```diff
@@ -48,7 +48,7 @@ enum { spi_dir_read = 0, spi_dir_write, spi_dir_readwrite };
 
 
 int libspi_transaction(libspi_ctx_t *ctx, int dir, unsigned char cmd, unsigned int addr, unsigned char flags,
-       unsigned char *ibuff, const unsigned char *obuff, size_t bufflen);
+               unsigned char *ibuff, const unsigned char *obuff, size_t bufflen);
 ```

- Add `InsertNewlineAtEOF`  set to `true` to force adding new line at the end of file (new in clang-format-16)
```diff
@@ -59,4 +59,4 @@ void gpio_setDir(oid_t *device, int gpio, int pin, int dir)
        imsg->gpio.dir.mask = 1 << pin;
 
        msgSend(device->port, &msg);
-}
\ No newline at end of file
+}
```
- Change `AllowShortLoopsOnASingleLine` from `true` to `false` to better match our coding standards
```diff
@@ -53,7 +53,8 @@ static void _hal_consolePrint(const char *s)
        for (; *s; s++)
                hal_consolePutch(*s);
 
-       while (!(*(console_common.UART + usr1) & 0x2000));
+       while (!(*(console_common.UART + usr1) & 0x2000))
+               ;
 }
```
- Update `AlignTrailingComments` and `AlignConsecutiveMacros` to new format (not change anything)
- Cosmetic change to remove apostrophes from boolean values (not change anything) 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To better match our coding standards
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

When this PR will be accepted, I will make PRs to other repos. 
