### PR TITLE
Add new target `armv7m7-imxrt117x-evkb` and add new ENET config for existing targets

### DIFF
--- a/_projects/armv7a7-imx6ull-evk/build.project
+++ b/_projects/armv7a7-imx6ull-evk/build.project
@@ -19,11 +19,6 @@ export LWIP_IPSEC_BUILD=no
 export LWIP_WIFI_BUILD=no
 
 #
-# Setup model of KSZ8081 On-Board Chip
-#
-export EPHY_KSZ8081=RNB
-
-#
 # Boot configuration
 #
 export KERNEL_PLO_BOOT=y

--- a/_projects/armv7a7-imx6ull-evk/build.project
+++ b/_projects/armv7a7-imx6ull-evk/build.project
@@ -21,7 +21,7 @@ export LWIP_WIFI_BUILD=no
 #
 # Setup model of KSZ8081 On-Board Chip
 #
-export EPHY_KSZ8081=RNA
+export EPHY_KSZ8081=RNB
 
 #
 # Boot configuration

--- a/_projects/armv7a7-imx6ull-evk/rootfs-overlay/etc/rc.psh
+++ b/_projects/armv7a7-imx6ull-evk/rootfs-overlay/etc/rc.psh
@@ -5,6 +5,6 @@ W /bin/bind devfs /dev
 X /sbin/imx6ull-gpio
 W /sbin/dummyfs -m /var -D
 W /sbin/dummyfs -m /tmp -D
-X /sbin/lwip enet:0x02188000:150:PHY:0.2:irq:-5:/dev/gpio5 enet:0x020b4000:152:no-mdio:PHY:0.1:irq:-6:/dev/gpio5
+X /sbin/lwip enet:0x02188000:150:PHY:0.2:irq:5:/dev/gpio5 enet:0x020b4000:152:no-mdio:PHY:0.1:irq:6:/dev/gpio5
 X /bin/posixsrv
 X /bin/psh

--- a/_projects/armv7a7-imx6ull-evk/rootfs-overlay/etc/rc.psh
+++ b/_projects/armv7a7-imx6ull-evk/rootfs-overlay/etc/rc.psh
@@ -5,6 +5,6 @@ W /bin/bind devfs /dev
 X /sbin/imx6ull-gpio
 W /sbin/dummyfs -m /var -D
 W /sbin/dummyfs -m /tmp -D
-X /sbin/lwip enet:0x02188000:150:PHY:0.2:irq:5:/dev/gpio5 enet:0x020b4000:152:no-mdio:PHY:0.1:irq:6:/dev/gpio5
+X /sbin/lwip enet:0x02188000:150:PHY:ksz8081rnb:0.2:irq:5:/dev/gpio5 enet:0x020b4000:152:no-mdio:PHY:ksz8081rnb:0.1:irq:6:/dev/gpio5
 X /bin/posixsrv
 X /bin/psh

--- a/_projects/armv7m7-imxrt106x-evk/build.project
+++ b/_projects/armv7m7-imxrt106x-evk/build.project
@@ -19,11 +19,6 @@ export LWIPOPTS_DIR
 export LWIP_IPSEC_BUILD=no
 export LWIP_WIFI_BUILD=no
 
-#
-# Setup model of KSZ8081 On-Board Chip
-#
-export EPHY_KSZ8081=RNB
-
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"
 }

--- a/_projects/armv7m7-imxrt106x-evk/build.project
+++ b/_projects/armv7m7-imxrt106x-evk/build.project
@@ -11,6 +11,19 @@
 : "${WATCHDOG:=0}"
 export WATCHDOG
 
+#
+# lwIP configuration
+#
+LWIPOPTS_DIR="$(pwd)/_projects/$TARGET/lwip"
+export LWIPOPTS_DIR
+export LWIP_IPSEC_BUILD=no
+export LWIP_WIFI_BUILD=no
+
+#
+# Setup model of KSZ8081 On-Board Chip
+#
+export EPHY_KSZ8081=RNB
+
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"
 }

--- a/_projects/armv7m7-imxrt106x-evk/lwip/lwipopts.h
+++ b/_projects/armv7m7-imxrt106x-evk/lwip/lwipopts.h
@@ -1,0 +1,100 @@
+#define LWIP_TCPIP_CORE_LOCKING      1
+#define LWIP_SUPPORT_CUSTOM_PBUF     1
+#define LWIP_NETIF_LOOPBACK          1
+#define LWIP_HAVE_SLIPIF             0
+#define LWIP_NETIF_API               1
+#define LWIP_SOCKET                  1
+#define LWIP_COMPAT_SOCKETS          0
+#define LWIP_ARP                     1
+#define LWIP_ICMP                    1
+#define LWIP_RAW                     1
+#define LWIP_NETPACKET               1
+#define LWIP_DHCP                    1
+#define LWIP_DNS                     1
+#define LWIP_AUTOIP                  1
+#define LWIP_UDP                     1
+#define LWIP_TCP                     1
+#define LWIP_TCP_KEEPALIVE           1
+#define MEM_LIBC_MALLOC              1
+#define MEMP_MEM_MALLOC              1
+#define LWIP_ERRNO_INCLUDE           "errno.h"
+#define LWIP_DNS_API_DEFINE_ERRORS   0
+#define LWIP_DNS_API_DEFINE_FLAGS    0
+#define LWIP_DNS_API_DECLARE_STRUCTS 0
+#define LWIP_DNS_API_DECLARE_H_ERRNO 0
+#define MEMP_NUM_NETCONN             1024
+#define PPP_SUPPORT                  1
+#define PPPOS_SUPPORT                1
+#define PAP_SUPPORT                  1
+#define CHAP_SUPPORT                 1
+#define MSCHAP_SUPPORT               0
+#define LWIP_TIMEVAL_PRIVATE         0
+
+#if 0  // debugging LWiP PPPoS
+#define LWIP_DEBUG         1
+#define LWIP_DBG_MIN_LEVEL LWIP_DBG_LEVEL_ALL
+#define LWIP_DBG_TYPES_ON  LWIP_DBG_ON
+#define PPP_DEBUG          LWIP_DBG_ON
+#define HAVE_DRIVER_pppos  1  // register and start PPPoS driver
+#define HAVE_DRIVER_pppou  1  // register and start PPPoU driver
+#endif
+
+#if 0
+#define LWIP_DEBUG         1
+#define LWIP_DBG_MIN_LEVEL LWIP_DBG_LEVEL_ALL
+#define LWIP_DBG_TYPES_ON  LWIP_DBG_ON
+#define PBUF_DEBUG         LWIP_DBG_ON
+#define ETHARP_DEBUG       LWIP_DBG_ON
+#define SOCKETS_DEBUG      LWIP_DBG_ON
+#endif
+
+#define TCP_MSS                       1460
+#define TCP_WND                       (32 * TCP_MSS)
+#define TCP_SND_BUF                   TCP_WND
+#define TCP_SND_QUEUELEN              192
+#define ETH_PAD_SIZE                  2
+#define ETHARP_TABLE_MATCH_NETIF      1
+#define IP_REASSEMBLY                 1
+#define IP_FRAG                       1
+#define SO_REUSE                      1
+#define DEFAULT_THREAD_STACKSIZE      (4 * 4096)
+#define TCPIP_THREAD_STACKSIZE        (4 * 4096)
+#define TCPIP_THREAD_PRIO             3
+#define TCPIP_MBOX_SIZE               256
+#define DEFAULT_RAW_RECVMBOX_SIZE     32
+#define DEFAULT_UDP_RECVMBOX_SIZE     32
+#define DEFAULT_TCP_RECVMBOX_SIZE     32
+#define DEFAULT_ACCEPTMBOX_SIZE       32
+#define LWIP_HOOK_FILENAME            "phoenix-hooks.h"
+#define LWIP_EXT_PF                   1
+#define LWIP_NETIF_STATUS_CALLBACK    1
+#define LWIP_DHCP_AUTOIP_COOP         1
+#define LWIP_DHCP_AUTOIP_COOP_TRIES   3
+#define LWIP_SO_RCVTIMEO              1
+#define LWIP_SO_SNDTIMEO              1
+#define ifreq                         lwip_ifreq
+#define LWIP_NETIF_LINK_CALLBACK      1
+#define LWIP_DHCP_GET_MOBILE_AGENT    1
+#define LWIP_EXT_IPSEC                1
+#define LWIP_LINKMONITOR_DEV          1
+#define LWIP_IFSTATUS_DEV_BUFFER_SIZE 1024
+#define LWIP_IFSTATUS_DEV             1
+
+/* required by Wi-Fi driver */
+#define PBUF_LINK_HLEN             44
+#define LWIP_NETIF_REMOVE_CALLBACK 1
+
+/* stats */
+#define LWIP_STATS         1
+#define LWIP_STATS_DISPLAY 1
+#define LINK_STATS         1
+#define IP_STATS           1
+#define ICMP_STATS         1
+#define IGMP_STATS         1
+#define IPFRAG_STATS       1
+#define UDP_STATS          1
+#define TCP_STATS          1
+#define MEM_STATS          1
+#define MEMP_STATS         1
+#define PBUF_STATS         1
+#define SYS_STATS          1

--- a/_projects/armv7m7-imxrt117x-evkb/board_config.h
+++ b/_projects/armv7m7-imxrt117x-evkb/board_config.h
@@ -1,0 +1,204 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Board config for armv7m7-imxrt117x-evkb
+ *
+ * Copyright 2022, 2024 Phoenix Systems
+ * Author: Lukasz Kosinski, Daniel Sawka
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _BOARD_CONFIG_H_
+#define _BOARD_CONFIG_H_
+
+
+/*
+ * libpseudodev and libposixsrv shall be used exclusively, libpseudodev uses
+ * less resources, but libposixsrv provides POSIX support and may be resource
+ * hungry, by default libposixsrv is enabled.
+ */
+
+/* #define PSEUDODEV 1 */
+#define BUILTIN_POSIXSRV 1
+
+
+/* Peripherals */
+
+
+#define UART_CONSOLE 1
+
+/* UART */
+
+#define UART1             1
+#define UART1_BAUDRATE    115200
+#define UART1_BUFSIZE     512
+#define UART1_TX_PIN      ad_24
+#define UART1_RX_PIN      ad_25
+#define UART1_HW_FLOWCTRL 0
+#define UART1_RTS_PIN     ad_27
+#define UART1_CTS_PIN     ad_26
+
+
+#define UART2             1
+#define UART2_BAUDRATE    115200
+#define UART2_BUFSIZE     512
+#define UART2_TX_PIN      disp_b2_10
+#define UART2_RX_PIN      disp_b2_11
+#define UART2_HW_FLOWCTRL 0
+#define UART2_RTS_PIN     disp_b2_13
+#define UART2_CTS_PIN     disp_b2_12
+
+/*
+#define UART3             0
+#define UART3_BAUDRATE    115200
+#define UART3_BUFSIZE     512
+#define UART3_TX_PIN      ad_30
+#define UART3_RX_PIN      ad_31
+#define UART3_HW_FLOWCTRL 0
+#define UART3_RTS_PIN     sd_b2_08
+#define UART3_CTS_PIN     sd_b2_07
+
+#define UART4             0
+#define UART4_BAUDRATE    115200
+#define UART4_BUFSIZE     512
+#define UART4_TX_PIN      disp_b1_06
+#define UART4_RX_PIN      disp_b1_04
+#define UART4_HW_FLOWCTRL 0
+#define UART4_RTS_PIN     disp_b1_07
+#define UART4_CTS_PIN     disp_b1_05
+
+#define UART5             0
+#define UART5_BAUDRATE    115200
+#define UART5_BUFSIZE     512
+#define UART5_TX_PIN      ad_28
+#define UART5_RX_PIN      ad_29
+#define UART5_HW_FLOWCTRL 0
+#define UART5_RTS_PIN     sd_b2_10
+#define UART5_CTS_PIN     sd_b2_09
+
+#define UART6             0
+#define UART6_BAUDRATE    115200
+#define UART6_BUFSIZE     512
+#define UART6_TX_PIN      emc_b1_40
+#define UART6_RX_PIN      emc_b1_41
+#define UART6_HW_FLOWCTRL 0
+#define UART6_RTS_PIN     emc_b2_01
+#define UART6_CTS_PIN     emc_b2_00
+
+#define UART7             0
+#define UART7_BAUDRATE    115200
+#define UART7_BUFSIZE     512
+#define UART7_TX_PIN      disp_b2_06
+#define UART7_RX_PIN      disp_b2_07
+#define UART7_HW_FLOWCTRL 0
+#define UART7_RTS_PIN     ad_03
+#define UART7_CTS_PIN     ad_02
+
+#define UART8             0
+#define UART8_BAUDRATE    115200
+#define UART8_BUFSIZE     512
+#define UART8_TX_PIN      disp_b2_08
+#define UART8_RX_PIN      disp_b2_09
+#define UART8_HW_FLOWCTRL 0
+#define UART8_RTS_PIN     ad_05
+#define UART8_CTS_PIN     ad_04
+
+#define UART9             0
+#define UART9_BAUDRATE    115200
+#define UART9_BUFSIZE     512
+#define UART9_TX_PIN      sd_b2_00
+#define UART9_RX_PIN      sd_b2_01
+#define UART9_HW_FLOWCTRL 0
+#define UART9_RTS_PIN     sd_b2_03
+#define UART9_CTS_PIN     sd_b2_02
+
+#define UART10             0
+#define UART10_BAUDRATE    115200
+#define UART10_BUFSIZE     512
+#define UART10_TX_PIN      ad_15
+#define UART10_RX_PIN      ad_16
+#define UART10_HW_FLOWCTRL 0
+#define UART10_RTS_PIN     ad_35
+#define UART10_CTS_PIN     ad_34
+
+#define UART11             0
+#define UART11_BAUDRATE    115200
+#define UART11_BUFSIZE     512
+#define UART11_TX_PIN      lpsr_08
+#define UART11_RX_PIN      lpsr_09
+#define UART11_HW_FLOWCTRL 0
+#define UART11_RTS_PIN     lpsr_11
+#define UART11_CTS_PIN     lpsr_10
+
+#define UART12             0
+#define UART12_BAUDRATE    115200
+#define UART12_BUFSIZE     512
+#define UART12_TX_PIN      lpsr_00
+#define UART12_RX_PIN      lpsr_01
+#define UART12_HW_FLOWCTRL 0
+#define UART12_RTS_PIN     lpsr_04
+#define UART12_CTS_PIN     lpsr_05
+*/
+
+/* SPI */
+
+/*
+#define SPI1      0
+#define SPI1_SCK  ad_28
+#define SPI1_SDO  ad_30
+#define SPI1_SDI  ad_31
+#define SPI1_PCS0 ad_29
+#define SPI1_PCS1 ad_18
+#define SPI1_PCS2 ad_19
+#define SPI1_PCS3 ad_20
+
+#define SPI2      0
+#define SPI2_SCK  sd_b2_07
+#define SPI2_SDO  sd_b2_09
+#define SPI2_SDI  sd_b2_10
+#define SPI2_PCS0 sd_b2_08
+#define SPI2_PCS1 sd_b2_11
+#define SPI2_PCS2 ad_22
+#define SPI2_PCS3 ad_23
+
+#define SPI3      0
+#define SPI3_SCK  disp_b1_04
+#define SPI3_SDO  disp_b1_06
+#define SPI3_SDI  disp_b1_05
+#define SPI3_PCS0 disp_b1_07
+#define SPI3_PCS1 disp_b1_08
+#define SPI3_PCS2 disp_b1_09
+#define SPI3_PCS3 disp_b1_10
+
+#define SPI4      0
+#define SPI4_SCK  disp_b2_12
+#define SPI4_SDO  disp_b2_14
+#define SPI4_SDI  disp_b2_13
+#define SPI4_PCS0 disp_b2_15
+#define SPI4_PCS1 sd_b2_04
+#define SPI4_PCS2 sd_b2_05
+#define SPI4_PCS3 sd_b2_06
+
+#define SPI5      0
+#define SPI5_SCK  lpsr_02
+#define SPI5_SDO  lpsr_04
+#define SPI5_SDI  lpsr_05
+#define SPI5_PCS0 lpsr_03
+#define SPI5_PCS1 lpsr_06
+#define SPI5_PCS2 lpsr_07
+#define SPI5_PCS3 lpsr_08
+
+#define SPI6      0
+#define SPI6_SCK  lpsr_10
+#define SPI6_SDO  lpsr_11
+#define SPI6_SDI  lpsr_12
+#define SPI6_PCS0 lpsr_09
+#define SPI6_PCS1 lpsr_08
+#define SPI6_PCS2 lpsr_07
+#define SPI6_PCS3 lpsr_06
+*/
+
+#endif

--- a/_projects/armv7m7-imxrt117x-evkb/build.project
+++ b/_projects/armv7m7-imxrt117x-evkb/build.project
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Shell script for building armv7m7-imxrt117x-evkb project
+#
+# Copyright 2022 Phoenix Systems
+# Author: Lukasz Kosinski
+#
+
+[ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
+
+: "${WATCHDOG:=0}"
+export WATCHDOG
+
+b_image_project () {
+	b_log "The images have been built for the ${TARGET} platform"
+}

--- a/_projects/armv7m7-imxrt117x-evkb/lwip/lwipopts.h
+++ b/_projects/armv7m7-imxrt117x-evkb/lwip/lwipopts.h
@@ -1,0 +1,100 @@
+#define LWIP_TCPIP_CORE_LOCKING      1
+#define LWIP_SUPPORT_CUSTOM_PBUF     1
+#define LWIP_NETIF_LOOPBACK          1
+#define LWIP_HAVE_SLIPIF             0
+#define LWIP_NETIF_API               1
+#define LWIP_SOCKET                  1
+#define LWIP_COMPAT_SOCKETS          0
+#define LWIP_ARP                     1
+#define LWIP_ICMP                    1
+#define LWIP_RAW                     1
+#define LWIP_NETPACKET               1
+#define LWIP_DHCP                    1
+#define LWIP_DNS                     1
+#define LWIP_AUTOIP                  1
+#define LWIP_UDP                     1
+#define LWIP_TCP                     1
+#define LWIP_TCP_KEEPALIVE           1
+#define MEM_LIBC_MALLOC              1
+#define MEMP_MEM_MALLOC              1
+#define LWIP_ERRNO_INCLUDE           "errno.h"
+#define LWIP_DNS_API_DEFINE_ERRORS   0
+#define LWIP_DNS_API_DEFINE_FLAGS    0
+#define LWIP_DNS_API_DECLARE_STRUCTS 0
+#define LWIP_DNS_API_DECLARE_H_ERRNO 0
+#define MEMP_NUM_NETCONN             1024
+#define PPP_SUPPORT                  1
+#define PPPOS_SUPPORT                1
+#define PAP_SUPPORT                  1
+#define CHAP_SUPPORT                 1
+#define MSCHAP_SUPPORT               0
+#define LWIP_TIMEVAL_PRIVATE         0
+
+#if 0  // debugging LWiP PPPoS
+#define LWIP_DEBUG         1
+#define LWIP_DBG_MIN_LEVEL LWIP_DBG_LEVEL_ALL
+#define LWIP_DBG_TYPES_ON  LWIP_DBG_ON
+#define PPP_DEBUG          LWIP_DBG_ON
+#define HAVE_DRIVER_pppos  1  // register and start PPPoS driver
+#define HAVE_DRIVER_pppou  1  // register and start PPPoU driver
+#endif
+
+#if 0
+#define LWIP_DEBUG         1
+#define LWIP_DBG_MIN_LEVEL LWIP_DBG_LEVEL_ALL
+#define LWIP_DBG_TYPES_ON  LWIP_DBG_ON
+#define PBUF_DEBUG         LWIP_DBG_ON
+#define ETHARP_DEBUG       LWIP_DBG_ON
+#define SOCKETS_DEBUG      LWIP_DBG_ON
+#endif
+
+#define TCP_MSS                       1460
+#define TCP_WND                       (32 * TCP_MSS)
+#define TCP_SND_BUF                   TCP_WND
+#define TCP_SND_QUEUELEN              192
+#define ETH_PAD_SIZE                  2
+#define ETHARP_TABLE_MATCH_NETIF      1
+#define IP_REASSEMBLY                 1
+#define IP_FRAG                       1
+#define SO_REUSE                      1
+#define DEFAULT_THREAD_STACKSIZE      (4 * 4096)
+#define TCPIP_THREAD_STACKSIZE        (4 * 4096)
+#define TCPIP_THREAD_PRIO             3
+#define TCPIP_MBOX_SIZE               256
+#define DEFAULT_RAW_RECVMBOX_SIZE     32
+#define DEFAULT_UDP_RECVMBOX_SIZE     32
+#define DEFAULT_TCP_RECVMBOX_SIZE     32
+#define DEFAULT_ACCEPTMBOX_SIZE       32
+#define LWIP_HOOK_FILENAME            "phoenix-hooks.h"
+#define LWIP_EXT_PF                   1
+#define LWIP_NETIF_STATUS_CALLBACK    1
+#define LWIP_DHCP_AUTOIP_COOP         1
+#define LWIP_DHCP_AUTOIP_COOP_TRIES   3
+#define LWIP_SO_RCVTIMEO              1
+#define LWIP_SO_SNDTIMEO              1
+#define ifreq                         lwip_ifreq
+#define LWIP_NETIF_LINK_CALLBACK      1
+#define LWIP_DHCP_GET_MOBILE_AGENT    1
+#define LWIP_EXT_IPSEC                1
+#define LWIP_LINKMONITOR_DEV          1
+#define LWIP_IFSTATUS_DEV_BUFFER_SIZE 1024
+#define LWIP_IFSTATUS_DEV             1
+
+/* required by Wi-Fi driver */
+#define PBUF_LINK_HLEN             44
+#define LWIP_NETIF_REMOVE_CALLBACK 1
+
+/* stats */
+#define LWIP_STATS         1
+#define LWIP_STATS_DISPLAY 1
+#define LINK_STATS         1
+#define IP_STATS           1
+#define ICMP_STATS         1
+#define IGMP_STATS         1
+#define IPFRAG_STATS       1
+#define UDP_STATS          1
+#define TCP_STATS          1
+#define MEM_STATS          1
+#define MEMP_STATS         1
+#define PBUF_STATS         1
+#define SYS_STATS          1

--- a/_targets/armv7m7/imxrt106x/user.plo.yaml
+++ b/_targets/armv7m7/imxrt106x/user.plo.yaml
@@ -9,5 +9,6 @@ contents:
   - app {{ env.BOOT_DEVICE }} -x imxrt-multi xip1 ocram2;aips14;aips5
   - app {{ env.BOOT_DEVICE }} -x psh xip1 ocram2
   - app {{ env.BOOT_DEVICE }} imxrt-flash ocram2 ocram2;aips14
+  - app {{ env.BOOT_DEVICE }} -xn lwip;enet:0x402D8000:130:PHY:0.2:irq:-10:/dev/gpio1:reset:-9:/dev/gpio1 xip1 dtcm;aips14
   - wait 2000
   - go!

--- a/_targets/armv7m7/imxrt106x/user.plo.yaml
+++ b/_targets/armv7m7/imxrt106x/user.plo.yaml
@@ -9,6 +9,6 @@ contents:
   - app {{ env.BOOT_DEVICE }} -x imxrt-multi xip1 ocram2;aips14;aips5
   - app {{ env.BOOT_DEVICE }} -x psh xip1 ocram2
   - app {{ env.BOOT_DEVICE }} imxrt-flash ocram2 ocram2;aips14
-  - app {{ env.BOOT_DEVICE }} -xn lwip;enet:0x402D8000:130:PHY:0.2:irq:-10:/dev/gpio1:reset:-9:/dev/gpio1 xip1 dtcm;aips14
+  - app {{ env.BOOT_DEVICE }} -xn lwip;enet:0x402D8000:130:PHY:ksz8081rnb:0.2:irq:-10:/dev/gpio1:reset:-9:/dev/gpio1 xip1 dtcm;aips14
   - wait 2000
   - go!

--- a/_targets/armv7m7/imxrt117x/preinit.plo.yaml
+++ b/_targets/armv7m7/imxrt117x/preinit.plo.yaml
@@ -4,7 +4,7 @@ is_relative: False
 contents:
   # NOTE: All data/code maps need to be cacheable to allow unaligned accesses
   - map itcm 0x0 0x40000 rwxcb
-  - map dtcm 0x20000000 0x20028000 rwcb
+  - map dtcm 0x20000000 0x20040000 rwcb
   - map ocram2 0x202c0000 0x20340000 rwxcb
   - map aips14 0x40000000 0x41000000 rws
   - map aips5 0x42000000 0x42100000 rws

--- a/_targets/armv7m7/imxrt117x/user.plo.yaml
+++ b/_targets/armv7m7/imxrt117x/user.plo.yaml
@@ -8,5 +8,6 @@ contents:
   - app {{ env.BOOT_DEVICE }} -x dummyfs xip1 ocram2
   - app {{ env.BOOT_DEVICE }} -x imxrt-multi xip1 ocram2;aips14;aips5
   - app {{ env.BOOT_DEVICE }} -x psh xip1 ocram2
+  - app {{ env.BOOT_DEVICE }} -xn lwip;enet:0x40424000:153:PHY:rtl8201fi-vc-cg:0.3:reset:12:/dev/gpio12:irq:-11:/dev/gpio9;enet:0x40420000:157:PHY:rtl8211fdi-cg:1.1:reset:-14:/dev/gpio11:irq:-13:/dev/gpio11 xip1 dtcm;aips14
   - wait 2000
   - go!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Provides necessary default configuration for iMX RT117x Ethernet driver and adds additional config for iMX 6ULL and iMX RT106x

## Motivation and Context
New target `armv7m7-imxrt117x-evkb` was needed because of significant differences between the PHYs and connections used on between iMX RT1170 EVK and EVKB boards. 
New config was added to iMX 6ULL and RT106x plo scripts to specify the PHY chip used on the board.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
If the dependent project uses ENET on any of the aforementioned platforms, the PHY chip model used on board has to be added just after "PHY" string to the lwip enet init, like so:
```diff
- enet:0x02188000:150:PHY:0.2:irq:5:/dev/gpio5
+ enet:0x02188000:150:PHY:ksz8081rnb:0.2:irq:5:/dev/gpio5
```
Additionally, any definition for KSZ8081 symbols can be removed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7a7-imx6ull-evk`, `armv7m7-imxrt106x-evk`, `arvmv7m7-imxrt117x-evkb` (newly added by this PR).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
