### PR TITLE
lighttpd: lighttpd.conf updates

### DIFF
--- a/_fs/root-skel/etc/lighttpd.conf
+++ b/_fs/root-skel/etc/lighttpd.conf
@@ -16,6 +16,7 @@ var.conf_dir    = "/etc/lighttpd"
 var.http_port  =   80
 var.https_port = 443
 
+## XXX: debug logging not recommended for production; may be noisy
 debug.log-file-not-found = "enable"
 #debug.log-request-handling = "enable"
 #debug.log-request-header = "enable"
@@ -29,20 +30,18 @@ server.port = http_port
 ## enabled modules
 server.modules = (
   "mod_indexfile",
-  "mod_dirlisting",
-  "mod_staticfile",
   "mod_access",
   "mod_accesslog",
   "mod_alias",
-  "mod_auth",
-  "mod_authn_file",
+#  "mod_auth",
+#  "mod_authn_file",
   "mod_openssl",
-#  "mod_evasive",
-  "mod_redirect",
+#  "mod_redirect",
   "mod_rewrite",
 #  "mod_setenv",
-#  "mod_usertrack",
   "mod_cgi"
+  "mod_dirlisting",
+  "mod_staticfile",
 )
 
 ## Document root
@@ -62,7 +61,7 @@ server.pid-file = state_dir + "/lighttpd.pid"
 # we can still serve static files and output of the CGI scripts. The only
 # exception is the '/log' subdir, where we want to get 404 error, if we're trying
 # to download log file that does not exist.
-url.rewrite-repeat-if-not-file = ( "^/(?!log/)(.*)" => "/index.html" )
+url.rewrite-repeat-if-not-file = ( "^/(?!log/)" => "/index.html" )
 
 #######################################################################
 ##  Logging Options
@@ -85,28 +84,28 @@ accesslog.format = "%h %l %u %t \"%r\" %b %>s \"%{user-agent}i\" \"%{referer}i\"
 
 #######################################################################
 ##  Tuning/Performance
+## https://wiki.lighttpd.net/Docs_ResourceTuning
+## https://wiki.lighttpd.net/Docs_Performance
 #######################################################################
 server.event-handler = "poll"
-server.network-backend = "write"
-server.max-fds = 64
-server.stat-cache-engine = "simple"
+server.max-fds = 128
 
 ## performance options
+## (too low might lower performance due to client having to reconnect;
+##  too high might deny other clients if server.max-connections is reached)
 server.max-keep-alive-requests = 6
-server.max-keep-alive-idle = 15
-server.max-read-idle     = 60
-server.max-write-idle    = 360
 
 ## maximum concurrent connections the server will accept (1/2 of server.max-fds)
 server.max-connections = 16
 
-## 32 MB in kB, only applies to POST (header + body)
+## 32 MB in kB, max size of request header + request body + request trailers
 server.max-request-size = 32768
 
 #######################################################################
 ##  Filename/File handling
 #######################################################################
 
+## (XXX: prefer a shorter list)
 index-file.names += (
   "index.xhtml", "index.html", "index.htm", "default.htm", "index.cgi", "login.html"
 )
@@ -116,9 +115,6 @@ url.access-deny             = ( "~", ".inc" )
 
 ## which extensions should not be handle via static-file transfer
 static-file.exclude-extensions = ( ".cgi")
-
-## Should lighttpd follow symlinks?
-server.follow-symlink = "enable"
 
 ## defaults to /var/tmp as we assume it is a local harddisk
 server.upload-dirs = ( "/var/tmp" )
@@ -160,6 +156,8 @@ $HTTP["url"] =~ "/cgi-bin/" {
 #######################################################################
 
 # use HTTPS
+## (XXX: use better syntax available with modern lighttpd releases)
+## https://wiki.lighttpd.net/Docs_SSL
 $SERVER["socket"] == ":" + https_port {
     ssl.engine                  = "enable"
 #
@@ -168,11 +166,6 @@ $SERVER["socket"] == ":" + https_port {
 #    ssl.privkey                 = "/local/certs/inc.phoenix-rtos.com.key"
 #
     ssl.ca-file                 = "/etc/ca.crt"
-#    ssl.dh-file                 = "/etc/ssl/dhparam.pem"
-#
-#    ## enforce secure ciphering algorithms
-#    ssl.cipher-list             = "DHE-RSA-AES256-SHA256:AES256-SHA256:RC4:HIGH:!RC4-SHA:!MD5:!aNULL:!EDH:!AESGCM"
-#    ssl.honor-cipher-order      = "enable"
 #
 #    ## enable and enforce client certificate verification
 #    ssl.verifyclient.activate   = "disable"
@@ -183,6 +176,8 @@ $SERVER["socket"] == ":" + https_port {
 }
 
 ## Redirect all HTTP to HTTPS
+## (XXX: use better syntax available with modern lighttpd releases)
+## https://wiki.lighttpd.net/HowToRedirectHttpToHttps
 $HTTP["scheme"] == "http" {
     # capture vhost name with regex conditiona -> %0 in redirect pattern
     # must be the most inner block to the redirect rule
@@ -200,6 +195,7 @@ alias.url += ( "/log/" => "/var/log/", "/data/" => "/mnt/sdcdata/")
 #######################################################################
 ##  MIME type mappings
 #######################################################################
+# (XXX: omit for lighttpd 1.4.76 and later to use lighttpd builtin web types)
 mimetype.assign             = (
   ".pdf"          =>      "application/pdf",
   ".sig"          =>      "application/pgp-signature",


### PR DESCRIPTION
lighttpd: lighttpd.conf updates

## Description
- prefer lighttpd defaults
- resource tuning
- remove mod_evasive and mod_usertrack (removed from upstream)
- comment out modules not otherwise used in lighttpd.conf

## Motivation and Context
modern lighttpd with bug fixes and HTTP/2 (optional)
fixes issue blocking https://github.com/phoenix-rtos/phoenix-rtos-ports/pull/90

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
