### PR TITLE
zynqmp: fix build - add missing uart16550 config

### DIFF
--- a/_projects/aarch64a53-zynqmp-qemu/board_config.h
+++ b/_projects/aarch64a53-zynqmp-qemu/board_config.h
@@ -53,6 +53,10 @@
  */
 #define UART_CONSOLE_ROUTED_VIA_PL 0
 
+/* UART16550 configuration */
+#define UART16550_CONSOLE_USER -1
+#define UART16550_BAUDRATE     115200
+
 /* CAN bus configuration */
 #define CAN0_RX 25
 #define CAN0_TX 24

--- a/_projects/aarch64a53-zynqmp-som/board_config.h
+++ b/_projects/aarch64a53-zynqmp-som/board_config.h
@@ -55,6 +55,10 @@
  */
 #define UART_CONSOLE_ROUTED_VIA_PL 0
 
+/* UART16550 configuration */
+#define UART16550_CONSOLE_USER -1
+#define UART16550_BAUDRATE     115200
+
 /* CAN bus configuration */
 #define CAN0_RX -1
 #define CAN0_TX -1

--- a/_projects/aarch64a53-zynqmp-zcu104/board_config.h
+++ b/_projects/aarch64a53-zynqmp-zcu104/board_config.h
@@ -53,6 +53,10 @@
  */
 #define UART_CONSOLE_ROUTED_VIA_PL 0
 
+/* UART16550 configuration */
+#define UART16550_CONSOLE_USER -1
+#define UART16550_BAUDRATE     115200
+
 /* CAN 0 bus configuration (on ZCU104 it is not connected) */
 #define CAN0_RX -1
 #define CAN0_TX -1

--- a/scripts/aarch64a53-zynqmp-qemu.sh
+++ b/scripts/aarch64a53-zynqmp-qemu.sh
@@ -2,6 +2,9 @@
 #
 # Shell script for running Phoenix-RTOS on aarch64a53-zynqmp-qemu
 #
+# ZynqMP platform requires the forked Qemu version
+# This script was tested with https://github.com/Xilinx/qemu tag xilinx_v2024.2
+#
 # Copyright 2024 Phoenix Systems
 # Author: Jacek Maksymowicz
 #


### PR DESCRIPTION
Fix building of ZynqMP projects (added missing configuration macros)

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand using: 
 - ZCU104 evaluation board (both building project and running it on board)
 - SOM (building of aarch64a53-zynqmp-som), 
 - QEMU (both build and running on qemu)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
