### PR TITLE
zynqmp: fix AXI width config

### DIFF
--- a/_projects/aarch64a53-zynqmp-qemu/board_config.h
+++ b/_projects/aarch64a53-zynqmp-qemu/board_config.h
@@ -140,33 +140,26 @@
 #define GPIO1_20 -1
 #define GPIO1_21 -1
 
-/**
- * Width of FPD AXI Slave 0
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
- */
-#define FPD_AXI_S0_WIDTH 0x00
-
-/**
- * Width of FPD AXI Slave 1
+/*
+ * PS-PL AXI bus width configuration
  *
  * Possible values:
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
+ * - 0x0 = 32 bit width
+ * - 0x1 = 64 bit width
+ * - 0x2 = 128 bit width
  */
-#define FPD_AXI_S1_WIDTH 0x00
+#define AXI_WIDTH_CFG_32B  0x0
+#define AXI_WIDTH_CFG_64B  0x1
+#define AXI_WIDTH_CFG_128B 0x2
 
-/**
- * Width of LPD AXI
- *
- * Possible values:
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
- */
-#define LPD_AXI_WIDTH 0x00
+/** Width of FPD AXI Slave 0 */
+#define FPD_AXI_S0_WIDTH AXI_WIDTH_CFG_32B
+
+/** Width of FPD AXI Slave 1 */
+#define FPD_AXI_S1_WIDTH AXI_WIDTH_CFG_32B
+
+/** Width of LPD AXI */
+#define LPD_AXI_WIDTH AXI_WIDTH_CFG_32B
 
 #define DDRC_DERATEEN_VAL   0x00000200
 #define DDRC_PWRTMG_VAL     0x00408210

--- a/_projects/aarch64a53-zynqmp-som/board_config.h
+++ b/_projects/aarch64a53-zynqmp-som/board_config.h
@@ -142,33 +142,26 @@
 #define GPIO1_20 -1
 #define GPIO1_21 -1
 
-/**
- * Width of FPD AXI Slave 0
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
- */
-#define FPD_AXI_S0_WIDTH 0x00
-
-/**
- * Width of FPD AXI Slave 1
+/*
+ * PS-PL AXI bus width configuration
  *
  * Possible values:
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
+ * - 0x0 = 32 bit width
+ * - 0x1 = 64 bit width
+ * - 0x2 = 128 bit width
  */
-#define FPD_AXI_S1_WIDTH 0x00
+#define AXI_WIDTH_CFG_32B  0x0
+#define AXI_WIDTH_CFG_64B  0x1
+#define AXI_WIDTH_CFG_128B 0x2
 
-/**
- * Width of LPD AXI
- *
- * Possible values:
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
- */
-#define LPD_AXI_WIDTH 0x00
+/** Width of FPD AXI Slave 0 */
+#define FPD_AXI_S0_WIDTH AXI_WIDTH_CFG_32B
+
+/** Width of FPD AXI Slave 1 */
+#define FPD_AXI_S1_WIDTH AXI_WIDTH_CFG_32B
+
+/** Width of LPD AXI */
+#define LPD_AXI_WIDTH AXI_WIDTH_CFG_32B
 
 /* DDR controller parameters */
 #define DDRC_DERATEEN_VAL   0x00000200

--- a/_projects/aarch64a53-zynqmp-zcu104/board_config.h
+++ b/_projects/aarch64a53-zynqmp-zcu104/board_config.h
@@ -141,33 +141,26 @@
 #define GPIO1_20 -1
 #define GPIO1_21 -1
 
-/**
- * Width of FPD AXI Slave 0
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
- */
-#define FPD_AXI_S0_WIDTH 0x00
-
-/**
- * Width of FPD AXI Slave 1
+/*
+ * PS-PL AXI bus width configuration
  *
  * Possible values:
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
+ * - 0x0 = 32 bit width
+ * - 0x1 = 64 bit width
+ * - 0x2 = 128 bit width
  */
-#define FPD_AXI_S1_WIDTH 0x00
+#define AXI_WIDTH_CFG_32B  0x0
+#define AXI_WIDTH_CFG_64B  0x1
+#define AXI_WIDTH_CFG_128B 0x2
 
-/**
- * Width of LPD AXI
- *
- * Possible values:
- * - 0x00 = 32 bit width
- * - 0x01 = 64 bit width
- * - 0x10 = 128 bit width
- */
-#define LPD_AXI_WIDTH 0x00
+/** Width of FPD AXI Slave 0 */
+#define FPD_AXI_S0_WIDTH AXI_WIDTH_CFG_32B
+
+/** Width of FPD AXI Slave 1 */
+#define FPD_AXI_S1_WIDTH AXI_WIDTH_CFG_32B
+
+/** Width of LPD AXI */
+#define LPD_AXI_WIDTH AXI_WIDTH_CFG_32B
 
 /* DDR controller parameters */
 #define DDRC_DERATEEN_VAL   0x00000200


### PR DESCRIPTION
This change fixes values used to configure ZynqMP PS-PL AXI bus width

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: TEBF0808

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
