### PR TITLE
_projects: enable Coremark-PRO port in long test build

### DIFF
--- a/_projects/armv7a7-imx6ull-evk/build.project
+++ b/_projects/armv7a7-imx6ull-evk/build.project
@@ -35,6 +35,13 @@ export PLO_NOR_BOOT=y
 export PLO_DEVICES="flash-imx6ull uart-imx6ull usbc-cdc"
 
 #
+# Ports configuration - additional to the one from _targets
+#
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
+
+#
 # Project specific build
 #
 export BOOT_DEVICE="nor0"         # Default boot device

--- a/_projects/armv7a9-zynq7000-qemu/build.project
+++ b/_projects/armv7a9-zynq7000-qemu/build.project
@@ -13,6 +13,13 @@ export FS_WRITE_CLEANMARKERS=y
 # No networking
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
 
+#
+# Ports configuration - additional to the one from _targets
+#
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
+
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"
 }

--- a/_projects/armv7a9-zynq7000-zedboard/build.project
+++ b/_projects/armv7a9-zynq7000-zedboard/build.project
@@ -15,6 +15,13 @@ export FS_WRITE_CLEANMARKERS=n
 # No networking
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
 
+#
+# Ports configuration - additional to the one from _targets
+#
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
+
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"
 }

--- a/_projects/armv7m4-stm32l4x6-nucleo/build.project
+++ b/_projects/armv7m4-stm32l4x6-nucleo/build.project
@@ -11,6 +11,13 @@
 : "${WATCHDOG:=0}"
 export WATCHDOG
 
+#
+# Ports configuration - additional to the one from _targets
+#
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
+
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"
 }

--- a/_projects/armv7m7-imxrt106x-evk/build.project
+++ b/_projects/armv7m7-imxrt106x-evk/build.project
@@ -24,6 +24,13 @@ export LWIP_WIFI_BUILD=no
 #
 export EPHY_KSZ8081=RNB
 
+#
+# Ports configuration - additional to the one from _targets
+#
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
+
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"
 }

--- a/_projects/armv7m7-imxrt117x-evk/build.project
+++ b/_projects/armv7m7-imxrt117x-evk/build.project
@@ -11,6 +11,13 @@
 : "${WATCHDOG:=0}"
 export WATCHDOG
 
+#
+# Ports configuration - additional to the one from _targets
+#
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
+
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"
 }

--- a/_projects/ia32-generic-qemu/build.project
+++ b/_projects/ia32-generic-qemu/build.project
@@ -23,7 +23,9 @@ export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
 #
 export PORTS_MBEDTLS=y
 export PORTS_AZURE_SDK=n # FIXME: requires port to macos
-
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
 
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"

--- a/_projects/riscv64-generic-qemu/build.project
+++ b/_projects/riscv64-generic-qemu/build.project
@@ -10,6 +10,13 @@
 
 export PLO_DEVICES="ram-storage uart-16550"
 
+#
+# Ports configuration - additional to the one from _targets
+#
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
+
 b_image_project () {
 	b_log "Adding PLO to Phoenix SBI"
 	# WARN: the plo embedded in SBI is being run, not the one in loader.disk


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enable building Coremark-PRO in projects tested in CI, when LONG_TEST is enabled
JIRA: CI-564

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m4-stm32l4x6-nucleo.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
