### PR TITLE
ci: bulid/test release branches using release docker images

### DIFF
--- a/.github/actions/phoenix-build/action.yml
+++ b/.github/actions/phoenix-build/action.yml
@@ -10,6 +10,10 @@ description: 'Builds Phoenix-RTOS based projects'
 
 # action input values
 inputs:
+  image-tag:
+    description: 'Docker image tag version'
+    default: 'latest'
+    required: false
   target:
     description: 'Target env variable'
     default: 'ia32-generic-qemu'
@@ -26,18 +30,35 @@ inputs:
     default: 'false'
     required: false
 
-# action runner
+# we're using a composite action as `docker` action type doesn't allow non-static image specification
 runs:
-  using: 'docker'
-  image: 'ghcr.io/phoenix-rtos/build'
-  env:
-    CONSOLE: 'serial'
-    DEBUG: '1'
-    TARGET: ${{ inputs.target }}
-    CI_CUSTOM_BUILDROOT: ${{ inputs.buildroot }}
-    LONG_TEST: ${{ inputs.nightly == 'true' && 'y' || 'n' }}
-  args:
-    - ${{ inputs.params }}  # note: params will be split by build.sh internally
+  using: 'composite'
+  steps:
+  - name: Run phoenix-build container
+    shell: bash
+    run: |
+      IMAGE="ghcr.io/phoenix-rtos/build:${{ inputs.image-tag }}"
+      echo "Using Docker image: $IMAGE"
+
+      # Collect all GITHUB_* env vars and format as -e KEY - omit value to avoid secret leakage
+      GH_ENV_ARGS=$(env | grep ^GITHUB_ | cut -d= -f1 | sed 's/^/-e /')
+
+      docker run --rm --privileged \
+        -v "${{ github.workspace }}:/workspace" \
+        -w /workspace \
+        -v "${HOME}:/github/home" \
+        -v "${RUNNER_TEMP}:/github/workflow" \
+        -v "${GITHUB_ENV}:/github/file_commands/env" \
+        -v "${GITHUB_OUTPUT}:/github/file_commands/output" \
+        -e CI=true \
+        -e CONSOLE=serial \
+        -e DEBUG=1 \
+        -e TARGET="${{ inputs.target }}" \
+        -e CI_CUSTOM_BUILDROOT="${{ inputs.buildroot }}" \
+        -e LONG_TEST="${{ inputs.nightly == 'true' && 'y' || 'n' }}" \
+        $GH_ENV_ARGS \
+        "$IMAGE" \
+        "${{ inputs.params }}"
 
 # branding
 branding:

--- a/.github/actions/phoenix-runner/action.yml
+++ b/.github/actions/phoenix-runner/action.yml
@@ -6,6 +6,10 @@ name: 'phoenix-runner'
 description: 'Runs Phoenix-RTOS tests'
 
 inputs:
+  image-tag:
+    description: 'Docker image tag version'
+    default: 'latest'
+    required: false
   target:
     description: 'Specifies target to run tests'
     default: 'ia32-generic-qemu'
@@ -16,20 +20,44 @@ inputs:
     default: 'false'
     required: false
 
-
-# action runner
+# we're using a composite action as `docker` action type doesn't allow non-static image specification
 runs:
-  using: 'docker'
-  image: 'ghcr.io/phoenix-rtos/devel'
-  entrypoint: ./phoenix-rtos-tests/runner.py
-  args:
-    - '-v' # output SKIP subresults at a top level
-    - '-T${{ inputs.target }}'
-    # HACK: We can't pass an empty argument to the runner due to strict arg parsing.
-    # Additionally, there is no conditional arg in github actions. If this is not a nightly run
-    # then repeating the target flag is acceptable, the runner is OK with that.
-    - ${{ inputs.nightly == 'true' && '--nightly' || format('-T{0}', inputs.target) }}
-    - '-Oresults.csv'
+  using: 'composite'
+  steps:
+  - name: Run phoenix-build container
+    shell: bash
+    run: |
+      IMAGE="ghcr.io/phoenix-rtos/devel:${{ inputs.image-tag }}"
+      echo "Using Docker image: $IMAGE"
+
+      # Collect all GITHUB_* env vars and format as -e KEY - omit value to avoid secret leakage
+      GH_ENV_ARGS=$(env | grep ^GITHUB_ | cut -d= -f1 | sed 's/^/-e /')
+
+      # Build the nightly flag logic
+      NIGHTLY_ARG=""
+      if [ "${{ inputs.nightly }}" = "true" ]; then
+        NIGHTLY_ARG="--nightly"
+      fi
+
+      # runner args:
+      #  -v  # output SKIP subresults at a top level
+      #  -Oresults.csv # creates also junit xml
+      docker run --rm --privileged \
+        -v "${{ github.workspace }}:/workspace" \
+        -w /workspace \
+        -v "${HOME}:/github/home" \
+        -v "${RUNNER_TEMP}:/github/workflow" \
+        -v "${GITHUB_ENV}:/github/file_commands/env" \
+        -v "${GITHUB_OUTPUT}:/github/file_commands/output" \
+        -e CI=true \
+        -e TARGET="${{ inputs.target }}" \
+        $GH_ENV_ARGS \
+        --entrypoint="./phoenix-rtos-tests/runner.py" \
+        "$IMAGE" \
+          -v \
+          -T${{ inputs.target }} \
+          $NIGHTLY_ARG \
+          -Oresults.csv
 
 # branding
 branding:

--- a/.github/problem-matchers/sanitizer-errors.json
+++ b/.github/problem-matchers/sanitizer-errors.json
@@ -14,6 +14,20 @@
             ]
         },
         {
+            "owner": "sanitizer-runtime-errors-ansi-colored",
+            "pattern": [
+                {
+                    "__comment": "GH doesn't strip ANSI colors correctly (actions/runner#2341), strip them manually",
+                    "regexp": "^(?:\\x1b\\[[\\d;]+m)*(.*):(\\d+):(\\d+):(?:\\x1b\\[[\\d;]+m)*\\s+runtime (error):\\s+(?:\\x1b\\[[\\d;]+m)*(.*)(?:\\x1b\\[[\\d;]+m)*$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        },
+        {
             "owner": "sanitizer-errors",
             "pattern": [
                 {

--- a/.github/workflows/_send_google_chat.yml
+++ b/.github/workflows/_send_google_chat.yml
@@ -43,16 +43,7 @@ jobs:
                                                   "keyValue": {
                                                       "topLabel": "Repo",
                                                       "content": "${{ github.repository }}",
-                                                      "iconUrl": "https://git-scm.com/images/logos/logomark-black@2x.png",
-                                                      "button": {
-                                                          "textButton": {
-                                                              "text": "OPEN",
-                                                              "onClick": {
-                                                                  "openLink": {
-                                                                      "url": "${{ github.server_url }}/${{ github.repository }}"
-                                                                  }
-                                                              }
-                                                          }
+                                                      "iconUrl": "https://git-scm.com/images/logos/logomark-black@2x.png"
                                                       }
                                                   }
                                               },

--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -5,6 +5,11 @@ name: ci-project
 on:
   workflow_call:
     inputs:
+      image-tag:
+        type: string
+        description: 'Docker image tag version'
+        default: 'latest'
+        required: false
       build_params:
         type: string
         description: "parameters to build.sh script"
@@ -64,6 +69,7 @@ jobs:
         id: build
         uses: ./.github/actions/phoenix-build
         with:
+          image-tag: ${{ inputs.image-tag }}
           target: ${{ matrix.target }}
           params: ${{ inputs.build_params }} ${{ matrix.additional_params }}
           nightly: ${{ inputs.nightly }}
@@ -125,6 +131,7 @@ jobs:
         id: runner
         uses: ./.github/actions/phoenix-runner
         with:
+          image-tag: ${{ inputs.image-tag }}
           target: ${{ matrix.target }}
           nightly: ${{ inputs.nightly }}
 

--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -4,11 +4,6 @@ name: ci-project
 # on events
 on:
   workflow_call:
-    secrets:
-      CI_BOT_EMAIL_USERNAME:
-        required: false
-      CI_BOT_EMAIL_PASSWORD:
-        required: false
     inputs:
       build_params:
         type: string
@@ -26,8 +21,6 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
-    outputs:
-      build_result: ${{ steps.build.outcome }}
     strategy:
       matrix:
         target:
@@ -98,8 +91,6 @@ jobs:
     needs: build
     name: test EMU
     runs-on: ubuntu-latest
-    outputs:
-      runner_result: ${{ steps.runner.outcome }}
     strategy:
       fail-fast: false
       matrix:
@@ -150,8 +141,6 @@ jobs:
     needs: build
     name: test HW
     runs-on: ${{ matrix.target }}
-    outputs:
-      runner_result: ${{ steps.runner.outcome }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -10,11 +10,31 @@ on:
     branches:
       - 'release/*'
 
-#TODO: this uses `latest` docker image instead of the release one
 jobs:
+  # extract release tag to be used as docker image tag
+  get-image-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_tag.outputs.image_tag }}
+
+    steps:
+      - name: Set image tag based on branch
+        shell: bash
+        id: set_tag
+        run: |
+          if [[ "$GITHUB_BASE_REF" =~ ^release/([0-9]+\.[0-9]+)$ ]]; then
+            IMAGE_TAG="v${BASH_REMATCH[1]}"
+            echo "IMAGE_TAG: $IMAGE_TAG"
+            echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "image_tag=latest" >> $GITHUB_OUTPUT
+          fi
+
   call-ci:
+    needs: get-image-tag
     uses: ./.github/workflows/ci-project.yml
     with:
+      image-tag: ${{ needs.get-image-tag.outputs.tag }}
       build_params: all tests
       nightly: true
     secrets: inherit

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -5,6 +5,11 @@ name: ci-submodule
 on:
   workflow_call:
     inputs:
+      image-tag:
+        type: string
+        description: 'Docker image tag version'
+        default: 'latest'
+        required: false
       build_params:
         type: string
         description: "parameters to build.sh script"
@@ -80,6 +85,7 @@ jobs:
         id: build
         uses: ./.buildroot/phoenix-rtos-project/.github/actions/phoenix-build    # BUILD_DIRECTORY value, but we can't use templates here
         with:
+          image-tag: ${{ inputs.image-tag }}
           target: ${{ matrix.target }}
           params: ${{ inputs.build_params }} ${{ matrix.additional_params }}
           buildroot: ${{env.CI_CUSTOM_BUILDROOT}}
@@ -137,6 +143,7 @@ jobs:
         id: runner
         uses: ./.github/actions/phoenix-runner
         with:
+          image-tag: ${{ inputs.image-tag }}
           target: ${{ matrix.target }}
 
       - name: Upload runner results

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -4,11 +4,6 @@ name: ci-submodule
 
 on:
   workflow_call:
-    secrets:
-      CI_BOT_EMAIL_USERNAME:
-        required: false
-      CI_BOT_EMAIL_PASSWORD:
-        required: false
     inputs:
       build_params:
         type: string
@@ -25,8 +20,6 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
-    outputs:
-      build_result: ${{ steps.build.outcome }}
     strategy:
       matrix:
         target:
@@ -109,8 +102,6 @@ jobs:
     needs: build
     name: test EMU
     runs-on: ubuntu-latest
-    outputs:
-      runner_result: ${{ steps.runner.outcome }}
     strategy:
       fail-fast: false
       matrix:
@@ -162,8 +153,6 @@ jobs:
     needs: build
     name: test HW
     runs-on: ${{ matrix.target }}
-    outputs:
-      runner_result: ${{ steps.runner.outcome }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- ci-release: use docker release tag for CI
- ci: make docker image tag parametrizable
  Switch to composite action to dynamically choose docker image version.
  Also: run docker in privileged mode.
- ci: remove "go to repo" button in google chat notification
- ci: remove obsolete secrets/outputs
- ci: fix ubsan problem matcher colored output
  work around GH bug actions/runner#2341

## Motivation and Context

CI-582, CI-390

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
