### PR TITLE
riscv64-gr765-vcu118/board_config.h: add SPW_MAX_PACKET_LEN

### DIFF
--- a/_projects/riscv64-gr765-vcu118/board_config.h
+++ b/_projects/riscv64-gr765-vcu118/board_config.h
@@ -90,6 +90,8 @@
 #define SPW4_ACTIVE 0
 #define SPW5_ACTIVE 0
 
+#define SPW_MAX_PACKET_LEN 1024
+
 #define TEST_SPW_ADDR0 0x3
 #define TEST_SPW_ADDR1 0x4
 


### PR DESCRIPTION
JIRA: CSAT-226

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add `SPW_MAX_PACKET_LEN` to `board_config.h` to make it accessible for applications using `grspw2` driver.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-gr765-vcu118`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/428
- [ ] I will merge this PR by myself when appropriate.
