### PR TITLE
_projects: enable coremark_pro on aarch64a53-zynqmp-qemu

### DIFF
--- a/_projects/aarch64a53-zynqmp-qemu/build.project
+++ b/_projects/aarch64a53-zynqmp-qemu/build.project
@@ -13,6 +13,13 @@ export FS_WRITE_CLEANMARKERS=y
 # No networking
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
 
+#
+# Ports configuration - additional to the one from _targets
+#
+if [ "$LONG_TEST" = "y" ]; then
+	export PORTS_COREMARK_PRO=y
+fi
+
 # Use PCI Express PS GTR PHY init code
 export PCI_EXPRESS_INIT_TEBF0808_PHY=n
 # Use Xilinx NWL PCI Express driver (PCI Express located in processing subsystem)


### PR DESCRIPTION
Enable Coremark-PRO on aarch64a53-zynqmp-qemu target in long test build

JIRA: CI-564

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
  - https://github.com/phoenix-rtos/phoenix-rtos-ports/pull/122
- [ ] I will merge this PR by myself when appropriate.
