### PR TITLE
ci: fix image tag detection for release branches

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         id: set_tag
         run: |
-          if [[ "$GITHUB_BASE_REF" =~ ^release/([0-9]+\.[0-9]+)$ ]]; then
+          if [[ "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}" =~ ^release/([0-9]+\.[0-9]+)$ ]]; then
             IMAGE_TAG="v${BASH_REMATCH[1]}"
             echo "IMAGE_TAG: $IMAGE_TAG"
             echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Ensure workflows correctly detect release branches and assign a relase Docker image tag instead of falling back to latest, when running workflow for merged changes.

JIRA: CI-602

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
