### PR TITLE
_projects/armv8r53-mps3an536-qemu: misrify board config

### DIFF
--- a/_projects/armv8r52-mps3an536-qemu/board_config.h
+++ b/_projects/armv8r52-mps3an536-qemu/board_config.h
@@ -26,7 +26,7 @@
 #define UART_BAUDRATE 115200
 
 /* UART0 accessible only by CPU0 */
-#define UART0_BASE ((void *)0xe7c00000)
+#define UART0_BASE ((void *)0xe7c00000U)
 /* CPU0 private interrupts */
 #define UART0_RX_IRQ   16
 #define UART0_TX_IRQ   17
@@ -44,32 +44,32 @@
 #define UART1_ACTIVE   0
 
 /* UARTs accessible by both CPUs */
-#define UART2_BASE     ((void *)0xe0205000)
+#define UART2_BASE     ((void *)0xe0205000U)
 #define UART2_RX_IRQ   (32 + 5)
 #define UART2_TX_IRQ   (32 + 6)
 #define UART2_COMB_IRQ (32 + 13)
 #define UART2_ACTIVE   1
 
-#define UART3_BASE     ((void *)0xe0206000)
+#define UART3_BASE     ((void *)0xe0206000U)
 #define UART3_RX_IRQ   (32 + 7)
 #define UART3_TX_IRQ   (32 + 8)
 #define UART3_COMB_IRQ (32 + 14)
 #define UART3_ACTIVE   0
 
-#define UART4_BASE     ((void *)0xe0207000)
+#define UART4_BASE     ((void *)0xe0207000U)
 #define UART4_RX_IRQ   (32 + 9)
 #define UART4_TX_IRQ   (32 + 10)
 #define UART4_COMB_IRQ (32 + 15)
 #define UART4_ACTIVE   0
 
-#define UART5_BASE     ((void *)0xe0208000)
+#define UART5_BASE     ((void *)0xe0208000U)
 #define UART5_RX_IRQ   (32 + 11)
 #define UART5_TX_IRQ   (32 + 12)
 #define UART5_COMB_IRQ (32 + 16)
 #define UART5_ACTIVE   0
 
 
-#define TIMER_BASE ((void *)0xe0101000)
+#define TIMER_BASE ((void *)0xe0101000U)
 #define TIMER_IRQ  (32 + 1)
 
 


### PR DESCRIPTION
The kernel needs these values to be unsigned to pass MISRA tests, there's no other way around it

JIRA: DO-3

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
