### PR TITLE
 _targets/stm32n6: use stm32n6_sign_fsbl.py for signing plo image

### DIFF
--- a/_targets/armv8m55/stm32n6/build.project
+++ b/_targets/armv8m55/stm32n6/build.project
@@ -11,9 +11,6 @@
 
 CROSS=arm-phoenix-
 
-# Path to STM32_SigningTool_CLI. User may wish to set a custom path.
-STM32SIGNTOOL=${STM32SIGNTOOL:="STM32_SigningTool_CLI"}
-
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
 export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
 export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
@@ -75,23 +72,12 @@ b_create_signed_bootloader() {
 	fi
 
 	b_log "Creating signed PLO image"
-	# STM32_SigningTool_CLI requires the binary to have ".bin" file extension,
-	# otherwise it will not be recognized as a flat binary file
-	PLO_UNSIGNED="${PREFIX_BOOT}/plo_unsigned.bin"
-	PLO_SIGNED="${PREFIX_BOOT}/part_plo.img"
-	cp "${PREFIX_PROG_STRIPPED}plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img" "${PLO_UNSIGNED}"
-	# Bit 0 - add authentication
-	# Bit 1 - add encryption
-	# Bit 31 - add padding
-	OUTPUT_FLAGS=0x80000000
-	${STM32SIGNTOOL} \
-		-bin "${PLO_UNSIGNED}" \
-		-nk \
-		-of ${OUTPUT_FLAGS} \
-		-t fsbl \
-		-o "${PLO_SIGNED}" \
-		-hv 2.3 \
-		-s
+	local plo_unsigned="${PREFIX_PROG_STRIPPED}plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img"
+	local plo_signed="${PREFIX_BOOT}/part_plo.img"
+	stm32n6_sign_fsbl.py \
+		-i "${plo_unsigned}" \
+		-o "${plo_signed}" \
+		-nk
 }
 
 


### PR DESCRIPTION
## Description
Previously our build script used `STM32_SigningTool_CLI` for signing the PLO image so it can boot on STM32N6. Unfortunately, this tool is proprietary so we don't have control over it and integrating it into our CI pipeline would be difficult. Also, version 2.21.0 breaks our build process, as it generates less padding than our application assumes.

We have our own open-source script that is now fully functional and can be used instead. The dependencies of this new script are stored in `phoenix-rtos-build/scripts/stm32n6_requirements.txt`.

## Motivation and Context
Fix RTOS-1199

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6-nucleo

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
