### PR TITLE
stm32u5: add armv8m33-stm32u5 minimal target

### DIFF
--- a/_targets/armv8m33/stm32u5/build.project
+++ b/_targets/armv8m33/stm32u5/build.project
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# Shell script for building armv8m33-stm32u5 project
+#
+# Copyright 2018, 2019, 2020, 2024 Phoenix Systems
+# Copyright 2026 Apator Metrix
+# Author: Kaja Swat, Aleksander Kaminski, Pawel Pisarczyk, Lukasz Kosinski, Mateusz Karcz
+#
+[ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
+
+. "_targets/build.common"
+
+CROSS=arm-phoenix-
+
+export BUSYBOX_CONFIG=$(realpath "busybox_config")
+export DROPBEAR_CUSTOM_CFLAGS="-DLTC_NO_BSWAP"
+export PSH_DEFUSRPWDHASH="0B1ANiYi45IhxkfmUW155/GBd4IRE="
+
+#
+# Ports configuration
+#
+export PORTS_BUSYBOX=n
+export PORTS_PCRE=n
+export PORTS_OPENSSL=n
+export PORTS_LIGHTTPD=n
+export PORTS_DROPBEAR=n
+export PORTS_LUA=n
+export PORTS_LZO=n
+export PORTS_OPENVPN=n
+export PORTS_JANSSON=n
+export PORTS_CURL=n
+export PORTS_COREMARK=n
+export PORTS_COREMARK_PRO=n
+
+
+#
+# Platform dependent parameters
+#
+export SIZE_PAGE=$((0x200))
+
+
+#
+# Project specific build
+#
+
+export BOOT_DEVICE="flash0"
+export MAGIC_USER_SCRIPT=dabaabad
+
+
+# Physical kernel address
+KERNEL_PHBASE=$((0x08000000)) # flash0 start address
+KERNEL_PHOFFS=$(image_builder.py query --nvm "$NVM_CONFIG" '{{ nvm.flash0.kernel.offs }}')
+KERNEL_PHADDR=$(printf "%08x" $((KERNEL_PHBASE + KERNEL_PHOFFS)))
+export KERNEL_PHADDR
+
+
+b_build_project() {
+	b_log "User applications skipped on STM32U5"
+}
+
+
+b_build_target() {
+	b_log "Building $TARGET project"
+	b_log "Building phoenix-rtos-loader"
+
+	image_builder.py script --nvm "$NVM_CONFIG" --script "$PLO_SCRIPT_PREINIT" --out script.plo
+	RAM_SCRIPT=1 image_builder.py script --nvm "$NVM_CONFIG" --script "$PLO_SCRIPT_PREINIT" --out script-ram.plo
+
+	make -C plo all
+
+	b_log "Creating kernel binary image"
+	KERNEL_ELF="phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf"
+	${CROSS}objcopy "${PREFIX_PROG_STRIPPED}${KERNEL_ELF}" -O binary "${PREFIX_PROG_STRIPPED}${KERNEL_ELF/.elf/.bin}"
+}
+
+
+b_image_target() {
+	image_builder.py -v partition --nvm "$NVM_CONFIG" --name user --script "$PLO_SCRIPT_USER"
+	image_builder.py -v disk --nvm "$NVM_CONFIG" --name flash0 --part "plo=${PREFIX_PROG_STRIPPED}plo-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.img" --out "phoenix.disk"
+}
+
+b_test_target() {
+	b_log "Tests skipped on STM32U5"
+}

--- a/_targets/armv8m33/stm32u5/nvm.yaml
+++ b/_targets/armv8m33/stm32u5/nvm.yaml
@@ -1,0 +1,16 @@
+flash0:
+  # internal flash - 2 banks 1 MB - assume the target image can't exceed one bank
+  size: 0x100000 # 1 MB
+  block_size: 0x100 # program page size
+  padding_byte: 0xff
+  partitions:
+    - name: plo
+      offs: 0x0
+    - name: user
+      offs: 0xc800
+      # if size not set - last non-virtual partition will be extnded to the end of flash
+
+    # virtual offset [user.offs] + [user.script.size]
+    - name: kernel
+      offs: 0xd000
+      virtual: True

--- a/_targets/armv8m33/stm32u5/preinit.plo.yaml
+++ b/_targets/armv8m33/stm32u5/preinit.plo.yaml
@@ -1,0 +1,22 @@
+size: 0x200
+is_relative: False
+
+contents:
+  # NOTE: All data/code maps need to be cacheable to allow unaligned accesses
+  # env.BOOT_DEVICE should correspond to one of the map names
+  - map flash0 0x08000000 0x08100000 rxcb
+  - map flash1 0x08100000 0x08200000 rxcb
+  - map ram 0x20000000 0x200c0000 rwxcb
+  - map io 0x40000000 0x60000000 rw
+  - phfs flash0 2.0 raw
+  - phfs flash1 2.1 raw
+  - phfs ramdev 4.0 raw
+  - console 0.0
+  - if: '{{ not(env.RAM_SCRIPT) | default(false) }}'
+    action: call
+    set_base: True
+    device: '{{ env.BOOT_DEVICE }}'
+    filename: user.plo
+    offset: '{{ nvm[env.BOOT_DEVICE].user.offs }}'
+    target_magic: '{{ env.MAGIC_USER_SCRIPT }}'
+

--- a/_targets/armv8m33/stm32u5/user.plo.yaml
+++ b/_targets/armv8m33/stm32u5/user.plo.yaml
@@ -1,0 +1,7 @@
+magic: '{{ env.MAGIC_USER_SCRIPT }}'
+size: '{{ nvm.flash0.kernel.offs - nvm.flash0.user.offs }}'
+is_relative: True
+
+contents:
+  - wait 1000
+  - stop Hello World!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add minimal target configuration for STM32U5 (768 kB base RAM, 2 MB dual-bank Flash).

This PR only enables building of PLO, not the kernel.
For successful Flash image generation, either a supplanted decoy kernel ELF, or relaxing of `image_builder.py` is required.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This enables building of PLO for STM32U5 family of microcontrollers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on:
  - STMicroelectronics B-U585I-IOT02A Discovery kit
  - proprietary Apator Metrix STM32U585 logic board

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-build/pull/254, future PR to plo).
- [ ] I will merge this PR by myself when appropriate.

Tagging: @kajaswat @anglov