### PR TITLE
ci: add cpptest job for submodule workflow

### DIFF
--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -20,6 +20,23 @@ on:
         default: false
         required: false
 
+      cpptest_enabled:
+        type: boolean
+        description: "enable cpptest analysis"
+        default: false
+        required: false
+      cpptest_targets:
+        type: string
+        description: "comma separated list of targets to run cpptest on"
+        # NOTE: ia32, RISC-V and SPARC targets are not suppoted by parasoft cpptest
+        default: 'armv7a7-imx6ull-evk, armv7m7-imxrt117x-evk, armv7r5f-zynqmp-qemu, aarch64a53-zynqmp-qemu'
+        required: false
+      cpptest_ruleset:
+        type: string
+        description: "cpptest ruleset to use (builtin or user)"
+        default: "user://MISRA C 2012 Phoenix"
+        required: false
+
 
 jobs:
   build:
@@ -106,6 +123,121 @@ jobs:
           path: |
             ${{env.BUILD_DIRECTORY}}/_boot/${{ matrix.target }}
             ${{env.BUILD_DIRECTORY}}/rootfs-${{ matrix.target }}.tar
+
+      - name: Upload compilation database artifacts
+        if: ${{ inputs.cpptest_enabled && contains(inputs.cpptest_targets, matrix.target) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: compile-db-artifacts-${{ matrix.target }}
+          retention-days: 1 # only to pass between jobs
+          path: |
+            ${{env.BUILD_DIRECTORY}}/_build/${{ matrix.target }}/sysroot
+            ${{env.BUILD_DIRECTORY}}/_build/${{ matrix.target }}/include
+            ${{env.BUILD_DIRECTORY}}/_build/${{ matrix.target }}/compile_commands.json
+
+
+  # convert cpptest_targets input into matrix format
+  cpptest_setup_targets:
+    if: inputs.cpptest_enabled
+    name: cpptest setup targets
+    runs-on: ubuntu-latest
+    outputs:
+      matrix-targets: ${{ steps.set-matrix.outputs.matrix-targets }}
+    steps:
+      - name: Set matrix targets
+        id: set-matrix
+        run: |
+          echo "matrix-targets=$(jq 'split(",") | map(sub("^\\s+"; "") | sub("\\s+$"; ""))' -Rc <(echo '${{ inputs.cpptest_targets }}'))" >> $GITHUB_OUTPUT
+
+  # run Parasoft CppTest on changed files only, using compile_commands.json from build job to get correct include paths and defines for accurate analysis
+  cpptest:
+    needs:
+      - build
+      - cpptest_setup_targets
+    name: cpptest
+    if: inputs.cpptest_enabled
+    runs-on: cpptest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.cpptest_setup_targets.outputs.matrix-targets) }}
+
+    steps:
+      - name: Checkout phoenix-rtos-project
+        uses: actions/checkout@v4
+        with:
+          repository: phoenix-rtos/phoenix-rtos-project
+          submodules: recursive
+
+      - name: Update submodule ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}
+        run: |
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/pull/*/head:refs/remotes/origin/pr/*"
+          git fetch --recurse-submodules=no --force ${{ github.event.repository.clone_url }} "+refs/pull/*/merge:refs/remotes/origin/pr/*"
+          git checkout ${{ github.sha }} || git checkout ${{ github.event.pull_request.head.sha }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47.0.1
+        with:
+          path: ${{ github.event.repository.name }}
+          files: |
+            **.c
+            **.h
+
+      - name: Download compile db artifacts
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: compile-db-artifacts-${{ matrix.target }}
+          path: _build/${{ matrix.target }}
+
+      - name: List all changed files
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
+
+      - name: Fix compile_commands.json paths
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          python3 ./scripts/ci/fix_compile_commands.py _build/${{ matrix.target }}/compile_commands.json > _build/${{ matrix.target }}/compile_commands-fixed.json
+          mv _build/${{ matrix.target }}/compile_commands-fixed.json _build/${{ matrix.target }}/compile_commands.json
+
+      # NOTE: this step will only analyze changed files - so code flow analysis quality is lower, but it will be much faster and more focused on changes in PRs.
+      - name: Run cpptest
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          # use ENV variables to pass inputs - resolves quoting/escaping issues
+          CPPTEST_CONFIG: ${{ inputs.cpptest_ruleset }}
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          CPPTEST_COMPILER: ${{ case(contains(matrix.target, 'aarch64'), 'gcc_14-aarch64', 'gcc_14-aarch32') }}
+        run: |
+          resources=()
+          for file in $ALL_CHANGED_FILES; do
+            resources+=("-resource" "$file")
+          done
+          cpptestcli -config "$CPPTEST_CONFIG" -input "_build/${{ matrix.target }}/compile_commands.json" \
+            -compiler "$CPPTEST_COMPILER" -module . -property report.format=sarif,html "${resources[@]}"
+
+      - name: Upload SARIF report
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: reports/report.sarif
+          checkout_path: ${{ github.workspace }}/${{ github.event.repository.name }}
+
+      - name: "Upload cpptest results"
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          path: reports/*
+          name: cpptest-reports-${{ matrix.target }}
+
 
   test-emu:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _boot/*
 compile_commands.json
 .cache/*
 .venv/
+.cpptest/
+reports/

--- a/scripts/ci/fix_compile_commands.py
+++ b/scripts/ci/fix_compile_commands.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Fixes paths in compile_commands.json to be relative and removes .buildroot GH hack."""
+
+import argparse
+import json
+import os
+import sys
+
+# Example JSON file when building "libphoenix" module
+EXAMPLE_JSON = """
+[
+    {
+        "arguments": [
+            "i386-pc-phoenix-gcc",
+            "-c",
+            "-D__TARGET_IA32",
+            "-D__CPU_GENERIC",
+            "-I/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/phoenix-rtos-lwip/include",
+            "-I/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_projects/ia32-generic-qemu",
+            "-m32",
+            "-march=i586",
+            "-mtune=generic",
+            "-mno-mmx",
+            "-mno-sse",
+            "-fno-pic",
+            "-fno-pie",
+            "-fomit-frame-pointer",
+            "-fno-builtin-malloc",
+            "--sysroot=/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/sysroot/",
+            "-B/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/sysroot/lib/",
+            "-iprefix",
+            "/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/sysroot/",
+            "-I/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/include/",
+            "-fmacro-prefix-map=/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/=",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-Wall",
+            "-Wstrict-prototypes",
+            "-Wundef",
+            "-Werror",
+            "-fno-common",
+            "-fno-strict-aliasing",
+            "-ggdb3",
+            "-O2",
+            "-Wundef",
+            "-Iinclude",
+            "-Ilib-lwip/src/include",
+            "-I/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_projects/ia32-generic-qemu/lwip",
+            "-Wno-char-subscripts",
+            "-Wno-format-zero-length",
+            "-o",
+            "/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/phoenix-rtos-lwip/lib-lwip/src/core/ipv4/etharp.o",
+            "lib-lwip/src/core/ipv4/etharp.c"
+        ],
+        "directory": "/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/phoenix-rtos-lwip",
+        "file": "lib-lwip/src/core/ipv4/etharp.c"
+    },
+    {
+        "arguments": [
+            "i386-pc-phoenix-gcc",
+            "-c",
+            "-D__TARGET_IA32",
+            "-D__CPU_GENERIC",
+            "-I/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_projects/ia32-generic-qemu",
+            "-m32",
+            "-march=i586",
+            "-mtune=generic",
+            "-mno-mmx",
+            "-mno-sse",
+            "-fno-pic",
+            "-fno-pie",
+            "-fomit-frame-pointer",
+            "-fno-builtin-malloc",
+            "--sysroot=/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/sysroot/",
+            "-B/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/sysroot/lib/",
+            "-iprefix",
+            "/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/sysroot/",
+            "-I/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/include/",
+            "-fmacro-prefix-map=/home/runner/work/libphoenix/=",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-Wall",
+            "-Wstrict-prototypes",
+            "-Wundef",
+            "-Werror",
+            "-fno-common",
+            "-fno-strict-aliasing",
+            "-ggdb3",
+            "-O2",
+            "-Iinclude",
+            "-fno-builtin-malloc",
+            "-o",
+            "/home/runner/work/libphoenix/libphoenix/.buildroot/phoenix-rtos-project/_build/ia32-generic-qemu/libphoenix/string/strdup.o",
+            "string/strdup.c"
+        ],
+        "directory": "/home/runner/work/libphoenix/libphoenix",
+        "file": "string/strdup.c"
+    }
+]
+"""
+
+def get_project_paths(data: list[dict], ROOT_REPO: str) -> tuple[str, str]:
+    """Detects root path of the project and repo name from compile_commands.json data.
+
+    Handles only submodule build case:
+      - "DIR/[repo]/.buildroot/[ROOT_REPO]/**" <- project root
+      - "DIR/[repo]/" <- repo
+
+    See ci-submodule.yml for details on how the build is set up in GH actions.
+    """
+    root_path = ""
+    repos = set()
+
+    for record in data:
+        if ROOT_REPO in record["directory"]:
+            if not root_path:
+                root_path = record["directory"].split(ROOT_REPO)[0] + ROOT_REPO
+        else:
+            repo = record["directory"].split(os.sep)[-1]
+            repos.add(repo)
+
+    assert len(repos) == 1, f"Expected exactly one repo, found: {repos}"
+    return root_path, repos.pop()
+
+def fix_compile_commands(data: list[dict], verbose: bool = False) -> None:
+    """We're changing the paths as in normal superproject build:
+     - use relative paths instead of absolute ones, skip ROOT_REPO part of the path
+     - [repo]/.buildroot/[ROOT_REPO] -> [ROOT_REPO]/[repo]"""
+    ROOT_REPO = "phoenix-rtos-project"
+    CWD = os.getcwd()
+
+    root_path, repo = get_project_paths(data, ROOT_REPO)
+
+    if verbose:
+        print(f"Detected root path: {root_path}", file=sys.stderr)
+        print(f"Detected repo: {repo}", file=sys.stderr)
+
+
+    for record in data:
+        if ROOT_REPO in record["directory"]:
+            record["directory"] = record["directory"].replace(root_path, CWD)
+        else:
+            record["directory"] = CWD + "/" + repo
+
+        for i, arg in enumerate(record["arguments"]):
+            if ROOT_REPO in arg: # path is a part of argument
+                fixed_arg = arg.replace(root_path, CWD)
+                record["arguments"][i] = fixed_arg
+
+
+def parse_opts() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fix compile commands paths to be relative")
+
+    parser.add_argument("--verbose", action="store_true", default=False)
+    parser.add_argument("file")
+
+    opts = parser.parse_args()
+    return opts
+
+
+def main() -> None:
+    opts = parse_opts()
+
+    with open(opts.file, "r") as f:
+        data = json.load(f)
+
+    fix_compile_commands(data, opts.verbose)
+    json.dump(data, fp=sys.stdout, indent=4)
+
+def test() -> None:
+    data = json.loads(EXAMPLE_JSON)
+    fix_compile_commands(data, verbose=False)
+    print(json.dumps(data, indent=4))
+
+if __name__ == "__main__":
+    # test()
+    main()


### PR DESCRIPTION
## Description

Makes it possible to use parasoft cpptest for MISRA compliance checking (among other tools). Findings are being reported as SARIF and uploaded to Github - standard GH constraints apply.

## Motivation and Context

YT: DO-430

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing: https://github.com/phoenix-rtos/libphoenix/pull/458
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
