### PR TITLE
_projects/armv8m55-stm32n6-nucleo: adjust trace buffer sizes

### DIFF
--- a/_projects/armv8m55-stm32n6-nucleo/board_config.h
+++ b/_projects/armv8m55-stm32n6-nucleo/board_config.h
@@ -34,6 +34,10 @@
 #define UART_CONSOLE_KERNEL 1
 #define UART_CONSOLE_USER   1
 
+/* Trace configuration */
+#define TRACE_EVENT_CHANNEL_BUFSIZE (256 << 10) /* 256 kB */
+#define TRACE_META_CHANNEL_BUFSIZE  (256 << 10) /* 256 kB */
+
 /*
  * libpseudodev and libposixsrv shall be used exclusively, libpseudodev uses
  * less resources, but libposixsrv provides POSIX support and may be resource


### PR DESCRIPTION
Default sizes are too large for this target's RAM size

JIRA: CI-639

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6-nucleo

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
