### PR TITLE
scripts: add openocd xilinx_zynqmp.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ To launch the created image on target architecture please see [docs.phoenix-rtos
 
 Phoenix-RTOS philosophy, architecture and internals are described in [docs.phoenix-rtos.com](https://docs.phoenix-rtos.com).
 
+## Licenses
+
+`phoenix-rtos-project` is licensed under the BSD 3-Clause License.
+
+It includes configuration scripts for external utilities, which are included solely for convenience and constitute a mere aggregation and do not form an integral part of the Phoenix-RTOS codebase. As such, they do not affect the licensing of the core project. The licensing terms for these specific scripts are declared within the files themselves and are accompanied by their respective license files.
+
 ## Product website
 
 Phoenix-RTOS website: [phoenix-rtos.com](https://phoenix-rtos.com).

--- a/scripts/openocd/zynqmp/LICENSE
+++ b/scripts/openocd/zynqmp/LICENSE
@@ -1,0 +1,351 @@
+Valid-License-Identifier: GPL-2.0-only
+Valid-License-Identifier: GPL-2.0-or-later
+SPDX-URL: https://spdx.org/licenses/GPL-2.0.html
+Usage-Guide:
+  To use this license in source code, put one of the following SPDX
+  tag/value pairs into a comment according to the placement
+  guidelines in the licensing rules documentation.
+  For 'GNU General Public License (GPL) version 2 only' use:
+    SPDX-License-Identifier: GPL-2.0-only
+  For 'GNU General Public License (GPL) version 2 or any later version' use:
+    SPDX-License-Identifier: GPL-2.0-or-later
+License-Text:
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/scripts/openocd/zynqmp/xilinx_zynqmp.cfg
+++ b/scripts/openocd/zynqmp/xilinx_zynqmp.cfg
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#
+# target configuration for
+# Xilinx ZynqMP (UltraScale+ / A53)
+#
+if { [info exists CHIPNAME] } {
+    set _CHIPNAME $CHIPNAME
+} else {
+    set _CHIPNAME uscale
+}
+
+#
+# DAP tap (Quard core A53)
+#
+if { [info exists DAP_TAPID] } {
+    set _DAP_TAPID $DAP_TAPID
+} else {
+    set _DAP_TAPID 0x5ba00477
+}
+
+jtag newtap $_CHIPNAME tap -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_DAP_TAPID
+dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.tap
+
+#
+# PS tap (UltraScale+)
+#
+if { [info exists PS_TAPID] } {
+    set _PS_TAPID $PS_TAPID
+    jtag newtap $_CHIPNAME ps -irlen 12 -ircapture 0x1 -irmask 0x03 -expected-id $_PS_TAPID
+} else {
+    # FPGA Programmable logic. Values take from Table 39-1 in UG1085:
+    jtag newtap $_CHIPNAME ps -irlen 12 -ircapture 0x1 -irmask 0x03 -ignore-version \
+        -expected-id 0x04711093 \
+        -expected-id 0x04710093 \
+        -expected-id 0x04721093 \
+        -expected-id 0x04720093 \
+        -expected-id 0x04739093 \
+        -expected-id 0x04730093 \
+        -expected-id 0x04738093 \
+        -expected-id 0x04740093 \
+        -expected-id 0x04750093 \
+        -expected-id 0x04759093 \
+        -expected-id 0x04758093
+}
+
+set jtag_configured 0
+
+jtag configure $_CHIPNAME.ps -event setup {
+    global _CHIPNAME
+    global jtag_configured
+
+    if { $jtag_configured == 0 } {
+        # add the DAP tap to the chain
+        # See https://forums.xilinx.com/t5/UltraScale-Architecture/JTAG-Chain-Configuration-for-Zynq-UltraScale-MPSoC/td-p/758924
+        irscan $_CHIPNAME.ps 0x824
+        drscan $_CHIPNAME.ps 32 0x00000003
+        runtest 100
+
+        # setup event will be re-entered through jtag arp_init
+        # break the recursion
+        set jtag_configured 1
+        # re-initialized the jtag chain
+        jtag arp_init
+    }
+}
+
+set _TARGETNAME $_CHIPNAME.a53
+set _CTINAME $_CHIPNAME.cti
+set _smp_command ""
+
+set DBGBASE {0x80410000 0x80510000 0x80610000 0x80710000}
+set CTIBASE {0x80420000 0x80520000 0x80620000 0x80720000}
+set _cores 4
+
+for { set _core 0 } { $_core < $_cores } { incr _core } {
+
+    cti create $_CTINAME.$_core -dap $_CHIPNAME.dap -ap-num 1 \
+        -baseaddr [lindex $CTIBASE $_core]
+
+    set _command "target create $_TARGETNAME.$_core aarch64 -dap $_CHIPNAME.dap \
+        -dbgbase [lindex $DBGBASE $_core] -cti $_CTINAME.$_core"
+
+    if { $_core != 0 } {
+        # non-boot core examination may fail
+        set _command "$_command -defer-examine"
+        set _smp_command "$_smp_command $_TARGETNAME.$_core"
+    } else {
+        set _command "$_command -rtos hwthread"
+        set _smp_command "target smp $_TARGETNAME.$_core"
+    }
+
+    eval $_command
+}
+
+target create uscale.axi mem_ap -dap uscale.dap -ap-num 0
+
+eval $_smp_command
+targets $_TARGETNAME.0
+
+proc core_up { args } {
+    global _TARGETNAME
+    foreach core $args {
+        $_TARGETNAME.$core arp_examine
+    }
+}
+
+proc BIT {n} {
+	return [expr {1 << $n}]
+}
+
+set IPI_BASE			0xff300000
+set IPI_PMU_0_TRIG		[expr {$IPI_BASE + 0x30000}]
+set IPI_PMU_0_IER		[expr {$IPI_BASE + 0x30018}]
+set IPI_PMU_0					[BIT 16]
+
+set CRF_APB_BASE		0xfd1a0000
+set CRF_APB_RST_FPD_APU		[expr {$CRF_APB_BASE + 0x104}]
+set CRF_APB_RST_FPD_APU_ACPU0_PWRON_RESET	[BIT 10]
+set CRF_APB_RST_FPD_APU_L2_RESET		[BIT  8]
+set CRF_APB_RST_FPD_APU_ACPU0_RESET		[BIT  0]
+
+set APU_BASE			0xfd5c0000
+set APU_RVBARADDR_BASE		[expr {$APU_BASE + 0x40}]
+
+set PMU_BASE			0xffd80000
+set PMU_GLOBAL			$PMU_BASE
+set PMU_GLOBAL_MB_SLEEP				[BIT 16]
+set PMU_GLOBAL_FW_IS_PRESENT			[BIT  4]
+set PMU_GLOBAL_DONT_SLEEP			[BIT  0]
+
+set PMU_RAM_BASE		0xffdc0000
+
+set OCM_RAM_BASE		0xfffc0000
+
+rename BIT {}
+
+add_help_text halt_pmu "Halt the PMU in preparation for loading new firmware.\
+	This should be matched with a call to resume_pmu."
+proc halt_pmu {} {
+	set axi $::_CHIPNAME.axi
+	set val [$axi read_memory $::IPI_PMU_0_IER 32 1]
+	$axi write_memory $::IPI_PMU_0_IER 32 [expr {$val | $::IPI_PMU_0}]
+
+	set val [$axi read_memory $::IPI_PMU_0_TRIG 32 1]
+	$axi write_memory $::IPI_PMU_0_TRIG 32 [expr {$val | $::IPI_PMU_0}]
+
+	set start [ms]
+	while {!([$axi read_memory $::PMU_GLOBAL 32 1] & $::PMU_GLOBAL_MB_SLEEP)} {
+		if {[ms] - $start > 1000} {
+			error "Timed out waiting for PMU to halt"
+		}
+	}
+}
+
+add_help_text resume_pmu "Resume the PMU after loading new firmware. This\
+	should be matched with a call to halt_pmu."
+proc resume_pmu {} {
+	set axi $::_CHIPNAME.axi
+	set val [$axi read_memory $::PMU_GLOBAL 32 1]
+	$axi write_memory $::PMU_GLOBAL 32 [expr {$val | $::PMU_GLOBAL_DONT_SLEEP}]
+
+	set start [ms]
+	while {!([$axi read_memory $::PMU_GLOBAL 32 1] & $::PMU_GLOBAL_FW_IS_PRESENT)} {
+		if {[ms] - $start > 5000} {
+			error "Timed out waiting for PMU firmware"
+		}
+	}
+}
+
+add_usage_text release_apu {apu}
+add_help_text release_apu "Release an APU from reset. It will start executing\
+	at RVBARADDR. You probably want resume_apu or start_apu instead."
+proc release_apu {apu} {
+	set axi $::_CHIPNAME.axi
+	set val [$axi read_memory $::CRF_APB_RST_FPD_APU 32 1]
+	set mask [expr {
+		(($::CRF_APB_RST_FPD_APU_ACPU0_PWRON_RESET | \
+		  $::CRF_APB_RST_FPD_APU_ACPU0_RESET) << $apu) | \
+		$::CRF_APB_RST_FPD_APU_L2_RESET
+	}]
+	$axi write_memory $::CRF_APB_RST_FPD_APU 32 [expr {$val & ~$mask}]
+
+	core_up $apu
+	$::_TARGETNAME.$apu aarch64 dbginit
+}
+
+proc _rvbaraddr {apu} {
+	return [expr {$::APU_RVBARADDR_BASE + 8 * $apu}]
+}
+
+add_usage_text resume_apu {apu addr}
+add_help_text resume_apu "Resume an APU at a given address."
+proc resume_apu {apu addr} {
+	set addrl [expr {$addr & 0xffffffff}]
+	set addrh [expr {$addr >> 32}]
+	$::_CHIPNAME.axi write_memory [_rvbaraddr $apu] 32 [list $addrl $addrh]
+
+	release_apu $apu
+}
+
+add_usage_text start_apu {apu}
+add_help_text start_apu "Start an APU and put it into an infinite loop at\
+	RVBARADDR. This can be convenient if you just want to halt the APU\
+	(since it won't execute anything unusual)."
+proc start_apu {apu} {
+	set axi $::_CHIPNAME.axi
+	foreach {addrl addrh} [$axi read_memory [_rvbaraddr $apu] 32 2] {
+		set addr [expr {($addrh << 32) | $addrl}]
+	}
+	# write the infinite loop instruction
+	$axi write_memory $addr 32 0x14000000
+
+	release_apu $apu
+}
+
+add_usage_text boot_pmu {image}
+add_help_text boot_pmu "Boot the PMU with a given firmware image, loading it\
+	to the beginning of PMU RAM. The PMU ROM will jump to this location\
+	after we resume it."
+proc boot_pmu {image} {
+	halt_pmu
+	echo "Info : Loading PMU firmware $image to $::PMU_RAM_BASE"
+	load_image $image $::PMU_RAM_BASE
+	resume_pmu
+}
+
+add_usage_text boot_apu "image \[apu=0 \[addr=$OCM_RAM_BASE\]\]"
+add_help_text boot_apu "Boot an APU with a given firmware image. The default\
+	address is the beginning of OCM RAM. Upon success, the default target\
+	will be changed to the (running) apu."
+proc boot_apu [list image {apu 0} [list addr $OCM_RAM_BASE]] {
+	start_apu $apu
+	targets $::_TARGETNAME.$apu
+	halt
+
+	echo "Info : Loading APU$apu firmware $image to $addr"
+	load_image $image $addr
+	resume $addr
+}

--- a/scripts/openocd/zynqmp/xilinx_zynqmp.cfg
+++ b/scripts/openocd/zynqmp/xilinx_zynqmp.cfg
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Original target configuration for Xilinx ZynqMP (UltraScale+ / A53)
+#
+# Additional RPU/APU boot procedures and helper functions:
+# Copyright (c) 2026 Phoenix Systems
+# Authors: Wladyslaw Mlynik, Lukasz Kruszynski
+#
 
-#
-# target configuration for
-# Xilinx ZynqMP (UltraScale+ / A53)
-#
 if { [info exists CHIPNAME] } {
     set _CHIPNAME $CHIPNAME
 } else {
@@ -96,12 +99,25 @@ for { set _core 0 } { $_core < $_cores } { incr _core } {
 target create uscale.axi mem_ap -dap uscale.dap -ap-num 0
 
 eval $_smp_command
+
+# R5 core configuration sourced from Tosainu:
+# https://gist.github.com/Tosainu/4d96d7d2c4528accdc931513d7075a3f
+target create $_CHIPNAME.r5.0 cortex_r4 -dap $_CHIPNAME.dap -dbgbase 0x803f0000 -coreid 0
+target create $_CHIPNAME.r5.1 cortex_r4 -dap $_CHIPNAME.dap -dbgbase 0x803f2000 -coreid 1
+
 targets $_TARGETNAME.0
 
 proc core_up { args } {
     global _TARGETNAME
     foreach core $args {
         $_TARGETNAME.$core arp_examine
+    }
+}
+
+proc rpu_up { args } {
+    global _CHIPNAME
+    foreach core $args {
+        $_CHIPNAME.r5.$core arp_examine
     }
 }
 
@@ -119,6 +135,13 @@ set CRF_APB_RST_FPD_APU		[expr {$CRF_APB_BASE + 0x104}]
 set CRF_APB_RST_FPD_APU_ACPU0_PWRON_RESET	[BIT 10]
 set CRF_APB_RST_FPD_APU_L2_RESET		[BIT  8]
 set CRF_APB_RST_FPD_APU_ACPU0_RESET		[BIT  0]
+
+set CRL_APB_BASE		0xff5e0000
+set CRL_APB_RST_LPD_TOP		[expr {$CRL_APB_BASE + 0x23c}]
+set CRL_APB_RST_LPD_TOP_RPU_PGE_RESET		[BIT  4]
+set CRL_APB_RST_LPD_TOP_OCM_RESET		[BIT  3]
+set CRL_APB_RST_LPD_TOP_RPU_AMBA_RESET		[BIT  2]
+set CRL_APB_RST_LPD_TOP_RPU_R50_RESET		[BIT  0]
 
 set APU_BASE			0xfd5c0000
 set APU_RVBARADDR_BASE		[expr {$APU_BASE + 0x40}]
@@ -168,6 +191,24 @@ proc resume_pmu {} {
 	}
 }
 
+add_usage_text release_rpu {rpu}
+add_help_text release_rpu "Release an RPU from reset. It will start executing\
+	at 0xffff0000. You probably want start_rpu instead."
+proc release_rpu {rpu} {
+	set axi $::_CHIPNAME.axi
+	set val [$axi read_memory $::CRL_APB_RST_LPD_TOP 32 1]
+	set mask [expr {
+		($::CRL_APB_RST_LPD_TOP_RPU_PGE_RESET | \
+         $::CRL_APB_RST_LPD_TOP_OCM_RESET | \
+         $::CRL_APB_RST_LPD_TOP_RPU_AMBA_RESET | \
+         ($::CRL_APB_RST_LPD_TOP_RPU_R50_RESET << $rpu))
+	}]
+	$axi write_memory $::CRL_APB_RST_LPD_TOP 32 [expr {$val & ~$mask}]
+
+	rpu_up $rpu
+    $::_CHIPNAME.r5.$rpu cortex_r4 dbginit
+}
+
 add_usage_text release_apu {apu}
 add_help_text release_apu "Release an APU from reset. It will start executing\
 	at RVBARADDR. You probably want resume_apu or start_apu instead."
@@ -212,6 +253,19 @@ proc start_apu {apu} {
 	$axi write_memory $addr 32 0x14000000
 
 	release_apu $apu
+}
+
+add_usage_text start_rpu {rpu}
+add_help_text start_rpu "Start an RPU and put it into an infinite loop. This\
+    can be convenient if you just want to halt the RPU\
+	(since it won't execute anything unusual)."
+proc start_rpu {rpu} {
+    set axi $::_CHIPNAME.axi
+    set addr 0xffff0000
+    # write the infinite loop instruction
+	$axi write_memory $addr 32 0xEAFFFFFE
+
+	release_rpu $rpu
 }
 
 add_usage_text boot_pmu {image}


### PR DESCRIPTION
JIRA: CI-648

Adding r5 support to xilinx_zynqmp config file.

## Description
Applying necessary modifications to the openocd's `xilinx_zynqmp.cfg` to work with r5 core.
The new openocd config will reside under `scripts/openocd/zynqmp/` for wider accessibility

## Motivation and Context
J-link would not target the r5 core otherwise. OpenOCD does not provide support for r5 in xilinx_zynqmp.cfg

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
