### PR TITLE
_targets: use global PROJECT_PATH var in build.common

### DIFF
--- a/_targets/build.common
+++ b/_targets/build.common
@@ -8,7 +8,6 @@
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
 KERNEL_ELF="phoenix-${TARGET_FAMILY}-${TARGET_SUBFAMILY}.elf"
-PROJ_PATH="_projects/$TARGET"
 
 # If path variable $1 is unset or empty - set it to project-specific or target-specific path based on the existence of file $2
 # NOTE: empty variable case will be treated as error in future
@@ -26,9 +25,9 @@ b_set_default_path() {
 	fi
 
 	if [ -z "${!varname:-}" ]; then
-		if [ -e "$PROJ_PATH/$fname" ]; then
+		if [ -e "$PROJECT_PATH/$fname" ]; then
 			# indirect assignment to the variable with varname
-			printf -v "$varname" "%s" "$PROJ_PATH/$fname"
+			printf -v "$varname" "%s" "$PROJECT_PATH/$fname"
 		else
 			printf -v "$varname" "%s" "_targets/$TARGET_FAMILY/$TARGET_SUBFAMILY/$fname"
 		fi
@@ -41,8 +40,8 @@ b_set_default_path "PLO_SCRIPT_USER" "user.plo.yaml"
 
 PORTS_CONFIG="${PREFIX_PROJECT}/_targets/${TARGET_FAMILY}/${TARGET_SUBFAMILY}/ports.yaml"
 
-if [ -e "${PROJ_PATH}" ]; then
-  PORTS_CONFIG="${PORTS_CONFIG}:${PREFIX_PROJECT}/${PROJ_PATH}/ports.yaml"
+if [ -e "${PROJECT_PATH}" ]; then
+  PORTS_CONFIG="${PORTS_CONFIG}:${PROJECT_PATH}/ports.yaml"
 fi
 
 


### PR DESCRIPTION
YT: MSH-97

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Use existing global var PROJECT_PATH

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
