### PR TITLE
ci: improve test results reporting, problem matchers and notifications

### DIFF
--- a/.github/problem-matchers/test-runner.json
+++ b/.github/problem-matchers/test-runner.json
@@ -1,0 +1,15 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "phoenix-test-runner",
+            "severity": "error",
+            "pattern": [
+                {
+                    "__comment": "Matches test result lines from phoenix-rtos-tests runner, with or without ANSI color codes",
+                    "regexp": "^(?:\\u001b\\[[0-9;]*m)?(\\S+?)(?:\\u001b\\[[0-9;]*m)?:\\s*(?:\\u001b\\[[0-9;]*m)?FAIL(?:\\u001b\\[[0-9;]*m)?\\s*$",
+                    "message": 1
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/_send_google_chat.yml
+++ b/.github/workflows/_send_google_chat.yml
@@ -5,73 +5,157 @@ name: send-notif
 # on events
 on:
   workflow_call:
+  workflow_dispatch:  # allow manual trigger for testing
 
 jobs:
   send-notif:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Debug details
+    - name: Collect failed jobs
+      id: failed-jobs
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-          echo "Workflow name: ${{ github.workflow }}"
-          echo "Event name: ${{ github.event_name }}"
-          echo "Repo: ${{ github.repository	}}"
-          echo "Repo URL: ${{ github.repositoryUrl }}"
-          echo "Repo URL: ${{ github.server_url }}/${{ github.repository }}"
-          echo "Actions URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          FAILED_JOBS=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --paginate --jq '[.jobs[] | select(.conclusion == "failure") | {name: .name, url: .html_url}]' \
+            2>/dev/null | jq -s 'add // []') || FAILED_JOBS="[]"
+
+          echo "::group::Failed jobs JSON"
+          echo "$FAILED_JOBS" | jq .
+          echo "::endgroup::"
+
+          COUNT=$(echo "$FAILED_JOBS" | jq 'length')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+          # Build HTML bullet list — bold the target name in parentheses
+          echo "$FAILED_JOBS" | jq -r '.[] | "• " + (.name | gsub("\\((?<t>[^)]+)\\)"; "(<b>\(.t)</b>)"))' > /tmp/failed_jobs.txt
+
+          echo "::group::Failed jobs text"
+          cat /tmp/failed_jobs.txt
+          echo "::endgroup::"
+
+    - name: Download test results
+      id: download-results
+      uses: actions/download-artifact@v8
+      with:
+        name: Merged Unit Test Results
+        path: /tmp/results
+      continue-on-error: true
+
+    - name: Parse failed tests
+      id: failed-tests
+      if: steps.download-results.outcome == 'success'
+      run: |
+          echo "::group::Downloaded files"
+          ls -la /tmp/results/
+          echo "::endgroup::"
+
+          pip3 -q install junitparser
+          python3 << 'PYEOF' > /tmp/failed_tests.txt
+          import junitparser
+
+          xml = junitparser.JUnitXml.fromfile("/tmp/results/junit.xml")
+          failures = []
+          for suite in xml:
+              for case in suite:
+                  if case.result and any(isinstance(r, junitparser.Failure) for r in case.result):
+                      failures.append(case.name)
+          for name in failures[:20]:
+              # Format TARGET:TEST_PATH — bold the target for visual distinction
+              if ':' in name:
+                  target, test = name.split(':', 1)
+                  print(f"• <b>{target}</b>: {test}")
+              else:
+                  print(f"• {name}")
+          if len(failures) > 20:
+              print(f"  ... and {len(failures) - 20} more")
+          PYEOF
+
+          COUNT=$(wc -l < /tmp/failed_tests.txt)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+          echo "::group::Failed tests"
+          cat /tmp/failed_tests.txt
+          echo "::endgroup::"
+      env:
+        PIP_BREAK_SYSTEM_PACKAGES: 1
 
     - name: Send Google Chat Notification
+      env:
+        WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_CI_WEBHOOK }}
       run: |
-          curl --fail --location --request POST '${{ secrets.GOOGLE_CHAT_CI_WEBHOOK }}' \
-          --header 'Content-Type: application/json' \
-          --data-raw '{
-                          "cards": [
-                              {
-                                  "sections": [
-                                      {
-                                          "widgets": [
-                                              {
-                                                  "textParagraph": {
-                                                      "text": "Workflow '\''<b>${{ github.workflow }}</b>'\'' <b><font color='\''#ff0000'\''>FAILED</font></b>"
-                                                  }
-                                              }
-                                          ]
-                                      },
-                                      {
-                                          "widgets": [
-                                              {
-                                                  "keyValue": {
-                                                      "topLabel": "Repo",
-                                                      "content": "${{ github.repository }}",
-                                                      "iconUrl": "https://git-scm.com/images/logos/logomark-black@2x.png"
-                                                  }
-                                              },
-                                              {
-                                                  "keyValue": {
-                                                      "topLabel": "Event",
-                                                      "icon": "TICKET",
-                                                      "content": "${{ github.event_name }}"
-                                                  }
-                                              },
-                                              {
-                                                  "buttons": [
-                                                      {
-                                                          "textButton": {
-                                                              "text": "OPEN FAILED RUN",
-                                                              "onClick": {
-                                                                  "openLink": {
-                                                                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                                                                  }
-                                                              }
-                                                          }
-                                                      }
-                                                  ]
-                                              }
-                                          ]
-                                      }
-                                  ]
-                              }
-                          ]
-                      }'
+          FAILED_JOBS=$(cat /tmp/failed_jobs.txt 2>/dev/null || true)
+          FAILED_TESTS=$(cat /tmp/failed_tests.txt 2>/dev/null || true)
 
+          # Build the base sections array
+          BASE_SECTIONS=$(jq -n \
+            --arg workflow "${{ github.workflow }}" \
+            --arg repo "${{ github.repository }}" \
+            --arg event "${{ github.event_name }}" \
+            --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '[
+              {
+                widgets: [{
+                  textParagraph: {
+                    text: ("Workflow \u0027<b>" + $workflow + "</b>\u0027 <b><font color=\u0027#ff0000\u0027>FAILED</font></b>")
+                  }
+                }]
+              },
+              {
+                widgets: [
+                  {
+                    keyValue: {
+                      topLabel: "Repo",
+                      content: $repo,
+                      iconUrl: "https://git-scm.com/images/logos/logomark-black@2x.png"
+                    }
+                  },
+                  {
+                    keyValue: {
+                      topLabel: "Event",
+                      icon: "TICKET",
+                      content: $event
+                    }
+                  },
+                  {
+                    buttons: [{
+                      textButton: {
+                        text: "OPEN FAILED RUN",
+                        onClick: {
+                          openLink: {
+                            url: $run_url
+                          }
+                        }
+                      }
+                    }]
+                  }
+                ]
+              }
+            ]')
+
+          # Append failed jobs as a separate section (sections get auto-dividers)
+          if [ -n "$FAILED_JOBS" ]; then
+            JOBS_HTML=$(printf '<b>Failed jobs:</b>\n%s' "$FAILED_JOBS")
+            BASE_SECTIONS=$(echo "$BASE_SECTIONS" | jq --arg text "$JOBS_HTML" \
+              '. + [{"widgets": [{"textParagraph": {"text": $text}}]}]')
+          fi
+
+          # Append failed tests as a separate section
+          if [ -n "$FAILED_TESTS" ]; then
+            TESTS_HTML=$(printf '<b>Failed tests:</b>\n%s' "$FAILED_TESTS")
+            BASE_SECTIONS=$(echo "$BASE_SECTIONS" | jq --arg text "$TESTS_HTML" \
+              '. + [{"widgets": [{"textParagraph": {"text": $text}}]}]')
+          fi
+
+          # Wrap into cards payload
+          PAYLOAD=$(echo "$BASE_SECTIONS" | jq '{cards: [{sections: .}]}')
+
+          echo "::group::Payload"
+          echo "$PAYLOAD" | jq .
+          echo "::endgroup::"
+
+          curl --fail --location --request POST "$WEBHOOK_URL" \
+            --header 'Content-Type: application/json' \
+            --data "$PAYLOAD"
 

--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Add sanitizers problem matcher
         run: echo "::add-matcher::.github/problem-matchers/sanitizer-errors.json"
 
+      - name: Add test runner problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/test-runner.json"
+
       - name: Test runner
         id: runner
         uses: ./.github/actions/phoenix-runner
@@ -205,6 +208,9 @@ jobs:
       - name: Untar boot
         working-directory: _boot
         run: tar -xvf ../boot-${{ matrix.target }}.tar
+
+      - name: Add test runner problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/test-runner.json"
 
       - name: Test runner
         id: runner

--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       # step 1: checkout repository code inside the workspace directory of the runner
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -89,7 +89,7 @@ jobs:
 
       # step 5: upload project boot and rootfs tarballs as build artifacts
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: phoenix-rtos-${{ matrix.target }}
           path: |
@@ -107,12 +107,12 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload resulting traces
         if: matrix.target == 'ia32-generic-qemu' || matrix.target == 'riscv64-generic-qemu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: trace-${{ matrix.target }}
           path: |
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload runner results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.target }}
           path: |
@@ -189,12 +189,12 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -219,7 +219,7 @@ jobs:
 
       - name: Upload runner results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.target }}
           path: |
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: test-results-*
@@ -249,7 +249,7 @@ jobs:
           PIP_BREAK_SYSTEM_PACKAGES: 1  # NOTE: we're running on emphemeral GH VMs, install packages globally
 
       - name: Upload Merged Unit Test Results in HTML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Merged Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -260,7 +260,10 @@ jobs:
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          check_name: Unit Test Results
+          check_name: >-
+            ${{ inputs.nightly && 'Unit Test Results (nightly)'
+                || github.event_name == 'schedule' && 'Unit Test Results (nightly-quick)'
+                || 'Unit Test Results' }}
           files: "junit.xml"
 
 

--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -268,7 +268,7 @@ jobs:
 
 
   send-notification:
-    needs: ['build', 'test-emu', 'test-hw']
-    if: failure() && github.event_name != 'pull_request'
+    needs: ['build', 'test-emu', 'test-hw', 'tests-summary']
+    if: "!cancelled() && failure() && github.event_name != 'pull_request'"
     uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/_send_google_chat.yml@master
     secrets: inherit

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -369,6 +369,9 @@ jobs:
       - name: Add sanitizers problem matcher
         run: echo "::add-matcher::.github/problem-matchers/sanitizer-errors.json"
 
+      - name: Add test runner problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/test-runner.json"
+
       - name: Test runner
         id: runner
         uses: ./.github/actions/phoenix-runner
@@ -444,6 +447,9 @@ jobs:
       - name: Untar rootfs
         working-directory: _fs
         run: tar -xvf ../rootfs-${{ matrix.target }}.tar
+
+      - name: Add test runner problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/test-runner.json"
 
       - name: Test runner
         id: runner

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -132,7 +132,7 @@ jobs:
     steps:
       # step 1 : checkout submodule
       - name: Checkout submodule
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -187,7 +187,7 @@ jobs:
 
       # step 5: upload project boot directory and tarball of rootfs as build artifacts
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: phoenix-rtos-${{ matrix.target }}
           path: |
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload compilation database artifacts
         if: ${{ inputs.cpptest_enabled && contains(inputs.cpptest_targets, matrix.target) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compile-db-artifacts-${{ matrix.target }}
           retention-days: 1 # only to pass between jobs
@@ -236,7 +236,7 @@ jobs:
 
     steps:
       - name: Checkout phoenix-rtos-project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
@@ -275,7 +275,7 @@ jobs:
       - name: Restore cpptest cache
         if: steps.should-analyze.outputs.run == 'true'
         id: cpptest-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .cpptest
           key: cpptest-${{ github.event.repository.name }}-${{ matrix.target }}-${{ github.sha }}
@@ -284,7 +284,7 @@ jobs:
 
       - name: Download compile db artifacts
         if: steps.should-analyze.outputs.run == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compile-db-artifacts-${{ matrix.target }}
           path: _build/${{ matrix.target }}
@@ -316,7 +316,7 @@ jobs:
       # Skipped when exact cache key already exists (re-run of same commit).
       - name: Save cpptest cache
         if: "!cancelled() && steps.should-analyze.outputs.run == 'true' && steps.cpptest-cache.outputs.cache-hit != 'true'"
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .cpptest
           key: cpptest-${{ github.event.repository.name }}-${{ matrix.target }}-${{ github.sha }}
@@ -330,7 +330,7 @@ jobs:
 
       - name: "Upload cpptest results"
         if: "!cancelled() && steps.should-analyze.outputs.run == 'true'"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: reports/*
           name: cpptest-reports-${{ matrix.target }}
@@ -348,7 +348,7 @@ jobs:
 
     steps:
       - name: Checkout phoenix-rtos-project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
@@ -358,7 +358,7 @@ jobs:
         uses: ./.github/actions/resolve-submodule-deps
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -402,7 +402,7 @@ jobs:
 
       - name: Upload resulting traces
         if: matrix.target == 'ia32-generic-qemu' || matrix.target == 'riscv64-generic-qemu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: trace-${{ matrix.target }}
           path: |
@@ -410,7 +410,7 @@ jobs:
 
       - name: Upload runner results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.target }}
           path: |
@@ -430,7 +430,7 @@ jobs:
 
     steps:
       - name: Checkout phoenix-rtos-project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
@@ -440,7 +440,7 @@ jobs:
         uses: ./.github/actions/resolve-submodule-deps
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: phoenix-rtos-${{ matrix.target }}
 
@@ -458,7 +458,7 @@ jobs:
 
       - name: Upload runner results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.target }}
           path: |
@@ -472,7 +472,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: test-results-*
@@ -489,7 +489,7 @@ jobs:
           PIP_BREAK_SYSTEM_PACKAGES: 1  # NOTE: we're running on emphemeral GH VMs, install packages globally
 
       - name: Upload Merged Unit Test Results in HTML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Merged Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -500,7 +500,10 @@ jobs:
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          check_name: Unit Test Results
+          check_name: >-
+            ${{ inputs.nightly && 'Unit Test Results (nightly)'
+                || github.event_name == 'schedule' && 'Unit Test Results (nightly-quick)'
+                || 'Unit Test Results' }}
           files: "junit.xml"
 
 

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -508,7 +508,7 @@ jobs:
 
 
   send-notification:
-    needs: ['build', 'test-emu', 'test-hw']
-    if: failure() && github.event_name != 'pull_request'
+    needs: ['build', 'test-emu', 'test-hw', 'tests-summary']
+    if: "!cancelled() && failure() && github.event_name != 'pull_request'"
     uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/_send_google_chat.yml@master
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 3  # current PR merge commit + 1 back
 
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2  # current PR merge commit + 1 back
 
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2  # current PR merge commit + 1 back
 
@@ -93,7 +93,7 @@ jobs:
     name: shellcheck-pr
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
## Description

- differentiate published unit test result check names for regular, nightly, and nightly-quick runs
- add a trunner problem matcher so failed tests produce CI annotations linked to the relevant log lines
- extend Google Chat failure notifications with failed jobs, failed tests, and more readable card formatting
- bump GitHub Actions versions used by CI workflows to Node.js 24 compatible releases

## Motivation and Context

The existing CI setup mixed unit test result baselines between different campaign types, did not annotate trunner failures in the Actions log, and sent Google Chat notifications with too little detail to triage failures quickly.

This change separates the result baselines for normal and nightly campaigns, makes trunner failures directly navigable from Actions annotations, and includes failed jobs plus parsed junit failures in the Google Chat notification.

It also updates GitHub Actions versions to remove Node.js 20 deprecation warnings in the workflows touched by this change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?

- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: GitHub Actions `workflow_dispatch` for `send-notif`; PR CI run with a temporary failing `phoenix-rtos-tests` branch to verify annotations, junit parsing, and Google Chat output.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

