### PR TITLE
_projects/riscv64-gr765-vcu118: SPWRTR port cnt / update submodules

### DIFF
--- a/_projects/riscv64-gr765-vcu118/board_config.h
+++ b/_projects/riscv64-gr765-vcu118/board_config.h
@@ -109,6 +109,8 @@
 #define SPWRTR4_ACTIVE 0
 #define SPWRTR5_ACTIVE 0
 
+#define SPWRTR_SPW_CNT  2
+#define SPWRTR_AMBA_CNT 2
 
 /* NAND configuration */
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add SPWRTR ports count config option 

## Description

* phoenix-rtos-devices b727ebc...ee18395 (2):
  > spacewire/grspwrtr: add clock divider for run-state
  > spacewire/grspwrtr.c: add more strict checks of the port number

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: CSAT-225

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
