### PR TITLE
_projects: enable storage on armv8m55-stm32n6-nucleo 

### DIFF
--- a/_projects/armv8m55-stm32n6-nucleo/board_config.h
+++ b/_projects/armv8m55-stm32n6-nucleo/board_config.h
@@ -22,6 +22,7 @@
 
 #define XSPI2           1
 #define XSPI2_CLOCK_DIV 1 /* 200 MHz */
+#define XSPI2_STORAGE   1
 
 #define VDDIO3_RANGE_MV 1800 /* XSPI port 2 - Flash */
 

--- a/_targets/armv8m55/stm32n6/build.project
+++ b/_targets/armv8m55/stm32n6/build.project
@@ -87,6 +87,16 @@ b_build_target() {
 
 
 b_image_target() {
+	if [[ $BOOT_DEVICE != "ramdisk" ]]; then
+		image_builder.py -v ptable --nvm "$NVM_CONFIG"
+		local storage_img="$PREFIX_BOOT/part_storage.img"
+		local storage_dir="$PREFIX_ROOTFS/mnt/storage/"
+		local erase_sz
+		local fs_sz
+		erase_sz=$(image_builder.py query --nvm "$NVM_CONFIG" '{{ nvm.flash0._meta.block_size }}')
+		fs_sz=$(image_builder.py query --nvm "$NVM_CONFIG" '{{ nvm.flash0.storage.size }}')
+		littlefs-image-create.py -t -S -s "$fs_sz" -b "$erase_sz" -i 4 -o "$storage_img" "$storage_dir"
+	fi
 	image_builder.py -v partition --nvm "$NVM_CONFIG" --name user --script "$PLO_SCRIPT_USER"
 	# STM32_Programmer_CLI requires the binary to have ".bin" file extension,
 	# otherwise it will not be recognized as a flat binary file

--- a/_targets/armv8m55/stm32n6/nvm.yaml
+++ b/_targets/armv8m55/stm32n6/nvm.yaml
@@ -1,9 +1,16 @@
 flash0:
   size: 0x4000000 # 64 MB
-  block_size: 0x10000 # program page size
+  # Erase sector size used by storage drivers on this platform (4 KB)
+  block_size: 0x1000
   padding_byte: 0xff
+  # Add 16 ptable blocks (16 * `block_size` == 64 KB) to align partition table with
+  # erase sector size used by STM32Programmer_CLI
+  ptable_blocks: 16
   partitions:
     - name: plo
       offs: 0x0
     - name: user
       offs: 0x10000
+    - name: storage
+      offs: 0x100000
+      size: 0x200000 # 2 MB

--- a/_targets/armv8m55/stm32n6/user.plo.yaml
+++ b/_targets/armv8m55/stm32n6/user.plo.yaml
@@ -6,6 +6,7 @@ is_relative: True
 contents:
   - kernel {{ env.BOOT_DEVICE }}
   - app {{ env.BOOT_DEVICE }} -xn psh axi_app axi_app
-  - app {{ env.BOOT_DEVICE }} -xn stm32l4-multi axi_app axi_app;per
+  - app {{ env.BOOT_DEVICE }} -xn stm32l4-multi axi_app axi_app;per;dmamem;flash0
+  - app {{ env.BOOT_DEVICE }} -xn flashdrv;-c;1;-m;0;-d;stm32-extflash axi_app axi_app
   - wait 1000
   - go!


### PR DESCRIPTION
## Description
Enable XSPI storage driver in userspace.
Add creation of disk image to build script.
Change NVM layout to add storage partition and partition table.
Add Flash driver to user script.

## Motivation and Context
JIRA: RTOS-1216

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6-nucleo

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
