### PR TITLE
ci: don't pass deleted filenames from git diff to shfmt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -116,7 +116,7 @@ jobs:
       - run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
       - run: |
-          git diff -z --name-only --ignore-submodules=all HEAD^ -- '*.sh' '*.project' '*.subr' | xargs -0 -r shfmt -i 0 -w
+          git diff -z --name-only --ignore-submodules=all --diff-filter=d HEAD^ -- '*.sh' '*.project' '*.subr' | xargs -0 -r shfmt -i 0 -w
 
       - uses: reviewdog/action-suggester@v1
         with:


### PR DESCRIPTION
By default, git diff --name-only will list deleted files that shmt fails to find, leading to CI errors.

JIRA: CI-667

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
