### PR TITLE
ZynqMP RPU: armv7r5f-zynqmp-zcu104 + watchdog config

### DIFF
--- a/_projects/armv7r5f-zynqmp-qemu/build.project
+++ b/_projects/armv7r5f-zynqmp-qemu/build.project
@@ -9,7 +9,7 @@
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
 # By default watchdog is enabled, to disable it set WATCHDOG=0, for example below.
-# Watchdog is also disabled when DEBUFG flag is defined.
+# Watchdog is also disabled when DEBUG flag is defined.
 : "${WATCHDOG:=0}"
 export WATCHDOG
 

--- a/_projects/armv7r5f-zynqmp-qemu/build.project
+++ b/_projects/armv7r5f-zynqmp-qemu/build.project
@@ -8,6 +8,11 @@
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
+# By default watchdog is enabled, to disable it set WATCHDOG=0, for example below.
+# Watchdog is also disabled when DEBUFG flag is defined.
+: "${WATCHDOG:=0}"
+export WATCHDOG
+
 export FS_WRITE_CLEANMARKERS=y
 
 # No networking

--- a/_projects/armv7r5f-zynqmp-som/build.project
+++ b/_projects/armv7r5f-zynqmp-som/build.project
@@ -9,7 +9,7 @@
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
 # By default watchdog is enabled, to disable it set WATCHDOG=0, for example below.
-# Watchdog is also disabled when DEBUFG flag is defined.
+# Watchdog is also disabled when DEBUG flag is defined.
 : "${WATCHDOG:=0}"
 export WATCHDOG
 

--- a/_projects/armv7r5f-zynqmp-zcu104/board_config.h
+++ b/_projects/armv7r5f-zynqmp-zcu104/board_config.h
@@ -3,12 +3,12 @@
  *
  * Board config for armv7r5f-zynqmp-som
  *
- * Copyright 2022, 2024, 2026 Phoenix Systems
- * Author: Lukasz Kosinski, Jacek Maksymowicz, Kamil Ber
+ * Copyright 2022, 2024 Phoenix Systems
+ * Author: Lukasz Kosinski, Jacek Maksymowicz
  *
  * This file is part of Phoenix-RTOS.
  *
- * BSD-3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _BOARD_CONFIG_H_
@@ -44,10 +44,10 @@
 /* UART configuration */
 #define UART0_BAUDRATE 115200
 
-#define UART0_RX 14
-#define UART0_TX 15
-#define UART1_RX 33
-#define UART1_TX 32
+#define UART0_RX 18
+#define UART0_TX 19
+#define UART1_RX 21
+#define UART1_TX 22
 
 #define UART_CONSOLE_KERNEL 0
 #define UART_CONSOLE_USER   0

--- a/_projects/armv7r5f-zynqmp-zcu104/build.project
+++ b/_projects/armv7r5f-zynqmp-zcu104/build.project
@@ -2,14 +2,14 @@
 #
 # Shell script for building armv7r5f-zynqmp-som project
 #
-# Copyright 2025 Phoenix Systems
-# Author: Jacek Maksymowicz
+# Copyright 2025, 2026 Phoenix Systems
+# Author: Damian Loewnau, Kamil Ber
 #
 
 [ "${BASH_SOURCE[0]}" -ef "$0" ] && echo "You should source this script, not execute it!" && exit 1
 
 # By default watchdog is enabled, to disable it set WATCHDOG=0, for example below.
-# Watchdog is also disabled when DEBUFG flag is defined.
+# Watchdog is also disabled when DEBUG flag is defined.
 : "${WATCHDOG:=0}"
 export WATCHDOG
 
@@ -18,6 +18,6 @@ export FS_WRITE_CLEANMARKERS=y
 # No networking
 export BUSYBOX_CONFIG="${PROJECT_PATH}/busybox_config"
 
-b_image_project () {
-	b_log "The images have been built for the ${TARGET} platform"
+b_image_project() {
+  b_log "The images have been built for the ${TARGET} platform"
 }

--- a/_projects/armv7r5f-zynqmp-zcu104/nvm.yaml
+++ b/_projects/armv7r5f-zynqmp-zcu104/nvm.yaml
@@ -1,0 +1,16 @@
+flash0:
+  size: 0x4000000 # 64 MB
+  block_size: 512
+  padding_byte: 0xff
+  partitions:
+    - name: plo
+      offs: 0x0
+    - name: kernel
+      offs: 0x40000
+    - name: rootfs
+      offs: 0x400000
+      size: 0x400000
+      type: jffs2
+    # provide empty virtual bitstr region for _target generic approach  to work
+    - name: bitstr
+      virtual: True

--- a/_projects/armv7r5f-zynqmp-zcu104/preinit.plo.yaml
+++ b/_projects/armv7r5f-zynqmp-zcu104/preinit.plo.yaml
@@ -1,0 +1,23 @@
+size: 0x1000
+is_relative: False
+
+contents:
+  - map atcm 0x00000 0x20000 rxcb # 0 ~ 128 KB
+  - map btcm 0x20000 0x40000 rwxcb # 128 ~ 256 KB
+  - map kddr 0x100000 0x400000 rwcb # 1 ~ 2 MB
+  - map ddr 0x400000 0x2000000 rwxcb # 2 ~ 32 MB
+  - map devs 0x80000000 0xfffc0000 rwbs # 2 GB ~ -256 KB
+  - map ocram 0xfffc0000 0x00000000 rcb # -256 KB ~ top of memory
+  - phfs uart0 0.0 raw
+  - phfs uart1 0.1 phoenixd
+  - phfs flash0 2.0 raw
+  - phfs ramdisk 4.0 raw
+  - console 0.0
+
+  - if: '{{ not(env.RAM_SCRIPT) | default(false) }}'
+    action: call
+    set_base: True
+    device: '{{ env.BOOT_DEVICE }}'
+    filename: user.plo
+    offset: '{{ nvm.flash0.kernel.offs }}'
+    target_magic: '{{ env.MAGIC_USER_SCRIPT }}'

--- a/scripts/ftdi_zcu104.cfg
+++ b/scripts/ftdi_zcu104.cfg
@@ -1,0 +1,8 @@
+adapter driver ftdi
+ftdi vid_pid 0x0403 0x6011
+ftdi channel 0
+ftdi layout_init 0x00c8 0x000b
+ftdi layout_signal POR_RST -data 0x0040 -oe 0x0040
+ftdi layout_signal nSRST -data 0x0080 -oe 0x0080
+transport select jtag
+adapter speed 8000


### PR DESCRIPTION
This PR introduces:

- new project: armv7r5f-zynqmp-zcu104
- default configuration for watchdog on armv7r5f-zynqmp targets/projects
- OpenOCD FDTI JTAG configuration script

In default configuration watchdog support is disabled for all 
armv7r5f-zynqmp targets. Once watchdog support is enabled 
(WATCHDOG = 1) user can also reconfigure it's state (enable/disable)
and reload value.

Default reload value of 0xFFF (effectively 0xFFFFFF watchdog clock cycles)
is set during platform initialization. For default 100MHz LPD_LSBUS_CLK
clock this gives refresh time of about 85.9s and per bit step of 5.12us.

YT: DO-836

## Motivation and Context
The ZynqMP RPU targets critical application in UAV domain. By default it is configured to run in lock-step. Watchdog support is required for this kind of applications.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ X] Tested by hand on: (list targets here).

Target: 
- armv7r5f-zynqmp-som

## Checklist:
- [ ] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
