### PR TITLE
_project: enable CI with coremark_pro for stm32n6

### DIFF
--- a/.github/workflows/ci-project.yml
+++ b/.github/workflows/ci-project.yml
@@ -185,7 +185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ['armv7a7-imx6ull-evk', 'armv7m7-imxrt106x-evk', 'armv7m7-imxrt117x-evk', 'armv7a9-zynq7000-zedboard', 'armv7m4-stm32l4x6-nucleo']
+        target: ['armv7a7-imx6ull-evk', 'armv7m7-imxrt106x-evk', 'armv7m7-imxrt117x-evk', 'armv7a9-zynq7000-zedboard', 'armv7m4-stm32l4x6-nucleo', 'armv8m55-stm32n6-nucleo']
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -426,7 +426,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ['armv7a7-imx6ull-evk', 'armv7m7-imxrt106x-evk', 'armv7m7-imxrt117x-evk', 'armv7a9-zynq7000-zedboard', 'armv7m4-stm32l4x6-nucleo']
+        target: ['armv7a7-imx6ull-evk', 'armv7m7-imxrt106x-evk', 'armv7m7-imxrt117x-evk', 'armv7a9-zynq7000-zedboard', 'armv7m4-stm32l4x6-nucleo', 'armv8m55-stm32n6-nucleo']
 
     steps:
       - name: Checkout phoenix-rtos-project

--- a/_projects/armv8m55-stm32n6-nucleo/ports.yaml
+++ b/_projects/armv8m55-stm32n6-nucleo/ports.yaml
@@ -1,0 +1,3 @@
+ports:
+  - name: coremark_pro
+    if: {{ bool(env.LONG_TEST) }}


### PR DESCRIPTION
JIRA: CI-686

## Description
Added YAML for enabling coremark_pro building and testing, also implemented the armv8m55 target into CI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6-nucleo 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
 - https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/504
- [ ] I will merge this PR by myself when appropriate.
