### PR TITLE
ci: fix cpptest changed-files detection on self-hosted runners

### DIFF
--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -246,15 +246,23 @@ jobs:
         uses: ./.github/actions/resolve-submodule-deps
 
       # For PRs: skip analysis entirely if no source files changed
+      # NOTE: deliberately NOT using tj-actions/changed-files here - as it fetches local branch and does not clean up.
+      # Asking the API keeps zero local git state.
       - name: Get changed files
         if: github.event_name == 'pull_request'
         id: changed-files
-        uses: tj-actions/changed-files@v47.0.1
-        with:
-          path: ${{ github.event.repository.name }}
-          files: |
-            **.c
-            **.h
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # NOTE: the API truncates at 3000 files - not a concern for our PRs
+          FILES=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
+          if grep -qE '\.[ch]$' <<< "${FILES}"; then
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Check if analysis needed
         id: should-analyze

--- a/.github/workflows/ci-submodule.yml
+++ b/.github/workflows/ci-submodule.yml
@@ -29,7 +29,7 @@ on:
         type: string
         description: "comma separated list of targets to run cpptest on"
         # NOTE: ia32, RISC-V and SPARC targets are not suppoted by parasoft cpptest
-        default: 'armv7a7-imx6ull-evk, armv7m7-imxrt117x-evk, armv7r5f-zynqmp-qemu, aarch64a53-zynqmp-qemu'
+        default: 'armv7a7-imx6ull-evk, armv7m7-imxrt117x-evk, armv7r5f-zynqmp-qemu, armv8m55-stm32n6-nucleo, aarch64a53-zynqmp-qemu'
         required: false
       cpptest_ruleset:
         type: string


### PR DESCRIPTION
## Description

Stop using `tj-actions/changed-files` in the `cpptest` job - ask the GitHub API for the PR file list instead.

Additionally: enable cpptest for `armv8m55-stm32n6-nucleo` by default.

## Motivation and Context

The `cpptest` job fails *permanently* for external (fork) contributions - e.g. phoenix-rtos/phoenix-rtos-kernel#812 - in the `Get changed files` step, with a misleading error:

> Failed to fetch pull request branch. Please ensure "persist-credentials" is set to "true"...

The real failure is a `git fetch` that `tj-actions/changed-files` runs under the hood:

```
$ /usr/bin/git fetch --no-tags --prune -u --progress origin pull/812/head:stm32u3-export
 ! [rejected]   refs/pull/812/head -> stm32u3-export  (non-fast-forward)
```

Root cause chain:

1. The submodule checkout is shallow, so `changed-files` fetches the PR head into a **local branch** named after the PR head ref, with a **non-forced** refspec.
2. Our `cpptest` runners are self-hosted with a persistent `_work` directory. `actions/checkout` resets/cleans the worktree but never deletes local branches, so every branch the action ever created is still there - there were **98** of them on both runners, in a workspace last cloned in February.
3. Once the contributor force-pushes/rebases, the stale branch is no longer an ancestor of the new PR head -> `non-fast-forward`.
4. `changed-files` then retries with a forced fallback refspec `+refs/heads/<head_ref>*`. **For our own PRs this silently repairs everything, which is why we never noticed.** For fork PRs that branch does not exist in our repository, so the fallback fails too and the job dies - permanently, no rerun can help.

Asking the API keeps zero local git state, so force-pushes, forks, shallow clones and workspace reuse all stop mattering. Only `any_changed` was ever consumed and the PR file list is already submodule-relative, so it is a drop-in replacement.

Since nothing in the pipeline creates local branches any more (`actions/checkout` and `resolve-submodule-deps` only write remote-tracking/forced refs), no recurring cleanup step is needed. The already accumulated branches have been purged from both runners manually.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?

- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7a7-imx6ull-evk`, `armv7m7-imxrt117x-evk`, `armv7r5f-zynqmp-qemu`, `armv8m55-stm32n6-nucleo`, `aarch64a53-zynqmp-qemu` (all cpptest targets).

This workflow cannot be exercised from this repository - submodules pin `ci-submodule.yml@master` and only phoenix-rtos-kernel sets `cpptest_enabled: true`. Verified via a throwaway draft PR phoenix-rtos/phoenix-rtos-kernel#832, whose WIP commit repoints `uses:` at this branch (to be closed and the branch deleted afterwards):

| case | commit touches | expected | [run](https://github.com/phoenix-rtos/phoenix-rtos-kernel/actions) | result |
|---|---|---|---|---|
| 1 | only `.yml` | `any_changed=false`, analysis skipped | [31708466186](https://github.com/phoenix-rtos/phoenix-rtos-kernel/actions/runs/31708466186) | 5/5 cpptest jobs green, `Get changed files` + `Check if analysis needed` succeeded, `Run cpptest` **skipped** |
| 2 | a `.c` file | `any_changed=true`, analysis runs | [31709312110](https://github.com/phoenix-rtos/phoenix-rtos-kernel/actions/runs/31709312110) | 5/5 cpptest jobs green, `Run cpptest` + `Upload SARIF report` **succeeded** on every target |

Both runs scheduled **5** cpptest matrix jobs instead of 4, which also confirms `armv8m55-stm32n6-nucleo` was picked up from the new default target list.

The step body was additionally dry-run locally against real PRs, including the fork PR whose fetch was permanently broken:

| PR | changed files | `any_changed` |
|---|---|---|
| phoenix-rtos-kernel#812 (fork, contains `.c`/`.h`) | 17 | `true` |
| phoenix-rtos-kernel#832 (only `.yml`) | 1 | `false` |
| phoenix-rtos-project#1739 (only `.yml`) | 1 | `false` |

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

TASK: DO-430
